### PR TITLE
Add dependency on Configuration module. - Fixes #7

### DIFF
--- a/build.depend.psd1
+++ b/build.depend.psd1
@@ -1,7 +1,8 @@
 @{
-    Configuration = @{
-        Name = 'Configuration'
+    PSDependOptions = @{
         Target = 'CurrentUser'
-        Version = 'latest'
     }
+
+    Configuration = 'latest'
+    Pester = 'latest'
 }

--- a/build.depend.psd1
+++ b/build.depend.psd1
@@ -1,0 +1,7 @@
+@{
+    Configuration = @{
+        Name = 'Configuration'
+        Target = 'CurrentUser'
+        Version = 'latest'
+    }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -26,7 +26,9 @@ try {
 
 
     # Restore dependencies
-    Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository (Get-PSRepository)[0].Name -Force
+    if (-not (Get-Module PSDepend -ListAvailable)) {
+        Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository PSGallery -Force
+    }
     Invoke-PSDepend -Path $PSScriptRoot\build.depend.psd1 -Confirm:$false
     Import-Module Configuration
 

--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,10 @@ try {
     ").Invoke() | Import-Module -Verbose:$false
 
 
-    # Restore dependencies (None)
+    # Restore dependencies
+    Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository (Get-PSRepository)[0].Name -Force
+    Invoke-PSDepend -Path $PSScriptRoot\build.depend.psd1 -Confirm:$false
+    Import-Module Configuration
 
     # Clean output if necessary (always)
     Write-Verbose "Cleaning output from $OutputDirectory"


### PR DESCRIPTION
Make use of PSDepend as documented in the README to handle the dependencies (see #7).

The explicit import of Configuration is due to it apparently not importing automatically and I'm not really sure why. If someone else can test on their machine without Configuration imported into the session then it would be good to find out if it's just my machine or not.

I'm not entirely happy with the use of -force -confirm:$false and all the other switches on Install-Module but it seems to be the only way to actually get the damn thing to install something. It might also need an Install-PackageProvider to handle installing nuget as well before this but hopefully if people are installing this from the gallery then it's already installed and ready to go.