### PR TITLE
add support to save tools instead of currentUser install. fixes #10

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ param(
     [switch]
     $UseLocalTools,
 
-    $GalleryToBootstrapFrom = 'PSGallery'
+    $Repository = 'PSGallery'
 )
 Write-Verbose "BUILDING $(Split-Path $PSScriptRoot -Leaf) VERSION $ModuleVersion" -Verbose
 $ErrorActionPreference = "Stop"
@@ -31,14 +31,14 @@ try {
 
     # Restore dependencies
     if (-not (Get-Module PSDepend -ListAvailable)) {
-        Write-Verbose "PSDepend not available, bootstrapping from Gallery '$GalleryToBootstrapFrom'"
+        Write-Verbose "PSDepend not available, bootstrapping from Repository '$Repository'"
         if (-not $UseLocalTools) {
-            Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository $GalleryToBootstrapFrom -Force
+            Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository $Repository -Force
         } else {
             $ToolsPath = Join-Path $PSScriptRoot 'Tools'
             Write-Debug "    Saving the PSDepend Module in '$ToolsPath"
             $null = New-Item -Name Tools -ItemType Directory -ErrorAction SilentlyContinue
-            Save-Module -Name PSDepend -Repository $GalleryToBootstrapFrom -Confirm:$false -Path $ToolsPath -ErrorAction Stop
+            Save-Module -Name PSDepend -Repository $Repository -Confirm:$false -Path $ToolsPath -ErrorAction Stop
             Write-Debug "    Adding $ToolsPath to `$Env:PSModulePath"
             if ($env:PSModulePath -split ';' -notcontains $ToolsPath) {
                 $env:PSModulePath = $ToolsPath + ';' + $env:PSModulePath

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,12 @@
 param(
     $OutputDirectory = "Output\ModuleBuilder",
 
-    $ModuleVersion = "1.0.0"
+    $ModuleVersion = "1.0.0",
+
+    [switch]
+    $SaveTools,
+
+    $GalleryToBootstrapFrom = 'PSGallery'
 )
 Write-Verbose "BUILDING $(Split-Path $PSScriptRoot -Leaf) VERSION $ModuleVersion" -Verbose
 $ErrorActionPreference = "Stop"
@@ -24,10 +29,19 @@ try {
         }
     ").Invoke() | Import-Module -Verbose:$false
 
-
     # Restore dependencies
     if (-not (Get-Module PSDepend -ListAvailable)) {
-        Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository PSGallery -Force
+        Write-Verbose "PSDepend not available, bootstrapping from Gallery '$GalleryToBootstrapFrom'"
+        if(-not $SaveTools) {
+            Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository $GalleryToBootstrapFrom -Force
+        } else {
+            $ToolsPath = Join-Path $PSScriptRoot 'Tools'
+            Write-Debug "    Saving the PSDepend Module in '$ToolsPath"
+            $null = New-Item -Name Tools -ItemType Directory -ErrorAction SilentlyContinue
+            Save-Module -Name PSDepend -Repository $GalleryToBootstrapFrom -Confirm:$false -Path $ToolsPath -ErrorAction Stop
+            Write-Debug "    Adding $ToolsPath to `$Env:PSModulePath"
+            $env:PSModulePath = $ToolsPath + ';' + $env:PSModulePath
+        }
     }
     Invoke-PSDepend -Path $PSScriptRoot\build.depend.psd1 -Confirm:$false
     Import-Module Configuration

--- a/build.ps1
+++ b/build.ps1
@@ -5,7 +5,7 @@ param(
     $ModuleVersion = "1.0.0",
 
     [switch]
-    $SaveTools,
+    $UseLocalTools,
 
     $GalleryToBootstrapFrom = 'PSGallery'
 )
@@ -32,7 +32,7 @@ try {
     # Restore dependencies
     if (-not (Get-Module PSDepend -ListAvailable)) {
         Write-Verbose "PSDepend not available, bootstrapping from Gallery '$GalleryToBootstrapFrom'"
-        if (-not $SaveTools) {
+        if (-not $UseLocalTools) {
             Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository $GalleryToBootstrapFrom -Force
         } else {
             $ToolsPath = Join-Path $PSScriptRoot 'Tools'

--- a/build.ps1
+++ b/build.ps1
@@ -40,7 +40,9 @@ try {
             $null = New-Item -Name Tools -ItemType Directory -ErrorAction SilentlyContinue
             Save-Module -Name PSDepend -Repository $GalleryToBootstrapFrom -Confirm:$false -Path $ToolsPath -ErrorAction Stop
             Write-Debug "    Adding $ToolsPath to `$Env:PSModulePath"
-            $env:PSModulePath = $ToolsPath + ';' + $env:PSModulePath
+            if($env:PSModulePath -split ';' -notcontains $ToolsPath) {
+                $env:PSModulePath = $ToolsPath + ';' + $env:PSModulePath
+            }
         }
     }
     Invoke-PSDepend -Path $PSScriptRoot\build.depend.psd1 -Confirm:$false

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ try {
     # Restore dependencies
     if (-not (Get-Module PSDepend -ListAvailable)) {
         Write-Verbose "PSDepend not available, bootstrapping from Gallery '$GalleryToBootstrapFrom'"
-        if(-not $SaveTools) {
+        if (-not $SaveTools) {
             Install-Module -Name PSDepend -Scope CurrentUser -Confirm:$False -Repository $GalleryToBootstrapFrom -Force
         } else {
             $ToolsPath = Join-Path $PSScriptRoot 'Tools'
@@ -40,7 +40,7 @@ try {
             $null = New-Item -Name Tools -ItemType Directory -ErrorAction SilentlyContinue
             Save-Module -Name PSDepend -Repository $GalleryToBootstrapFrom -Confirm:$false -Path $ToolsPath -ErrorAction Stop
             Write-Debug "    Adding $ToolsPath to `$Env:PSModulePath"
-            if($env:PSModulePath -split ';' -notcontains $ToolsPath) {
+            if ($env:PSModulePath -split ';' -notcontains $ToolsPath) {
                 $env:PSModulePath = $ToolsPath + ';' + $env:PSModulePath
             }
         }


### PR DESCRIPTION
- allows the user to specify which PSGallery to Bootstrap PSDepend from
- allows to save the tools (PSDepend) instead of installing in CurrentUser, and create the Folder if needed. It also Prepend the Tools folder to the `$Env:PSModulePath`

This does not change the ModuleBuilder module itself, but is a good example of how the `Build.ps1` needs to support it.

Changing the `build.depend.psd1` to the following is needed to save _all_ dependencies to the `Tools` folder:
```PowerShell
# build.depend.psd1
@{
    PSDependOptions = @{
        Target = 'Tools'
    }

    Configuration = 'latest'
    Pester = 'latest'
}

```