### PR TITLE
Extracting and changing the merging function. fixes #4

### DIFF
--- a/Source/Private/MergeIntoModule.ps1
+++ b/Source/Private/MergeIntoModule.ps1
@@ -1,0 +1,84 @@
+function MergeIntoModule {
+    [CmdletBinding()]
+    param(
+        # The ModuleInfo object of the source Module Manifest to Merge into one PSM1,
+        # potentially extended with a Suffix or Prefix as per Build-Module
+        [Parameter(ValueFromPipelineByPropertyName)]
+        $ModuleInfo,
+
+        # File to write the merged PSM1 to
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        $RootModule,
+
+        # Source Directories too include in the merge based on the $ModuleInfo.ModuleBase
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [string[]]$SourceDirectories = @(
+            "Enum", "Classes", "Private", "Public"
+        ),
+
+        # Script files to merge into the PSM1
+        [Parameter(ValueFromPipelineByPropertyName, ValueFromPipeline)]
+        $AllScripts = (Get-ChildItem -Path $SourceDirectories.ForEach{ Join-Path $ModuleInfo.ModuleBase $_ } -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue)    
+    )
+
+    begin {
+        $usingList = New-Object System.Collections.Generic.List[String]
+        $merge = New-Object System.Text.StringBuilder
+        $Separator = "`n"
+
+        if ($ModuleInfo.Prefix) {
+            Write-Verbose "Adding Prefix"
+            $prefix = if (Test-Path $ModuleInfo.Prefix) {
+                $SourceName = Resolve-Path $ModuleInfo.Prefix -Relative
+                "#Region '$SourceName' 0"
+                Get-Content $SourceName -OutVariable source
+                "#EndRegion '$SourceName' $($Source.Count)"
+            } else {
+                "#Region 'PREFIX' 0"
+                $ModuleInfo.Prefix
+                "#EndRegion 'PREFIX'"
+            }
+            $null = $merge.AppendFormat('{0}{1}', ($prefix | Out-String), $Separator)
+        } 
+    }
+    process {
+        foreach ($file in $AllScripts) {
+            $SourceName = Resolve-Path $file.FullName -Relative
+            Write-Verbose "Adding $SourceName"
+                
+            $content = & {
+                "#Region '$SourceName' 0"
+                $file | Get-Content | ForEach-Object {
+                    # Extracting the Using Statements to be insterted at the top of the psm1 file
+                    if ($_ -match '^using') {
+                        $usingList.Add($_)
+                    } else {
+                        $_.TrimEnd()
+                    }
+                }
+                "#EndRegion '$SourceName'"
+            }
+            $null = $merge.AppendFormat('{0}{1}', ($content | Out-String), $Separator)
+        }
+    }
+    end {
+        if ($ModuleInfo.Suffix) {
+            $Suffix = if (Test-Path $ModuleInfo.Suffix) {
+                $SourceName = Resolve-Path $ModuleInfo.Suffix -Relative
+                "#Region '$SourceName' 0"
+                Get-Content $SourceName
+                "#EndRegion '$SourceName'"
+            } else {
+                "#Region 'SUFFIX' 0"
+                $ModuleInfo.Suffix
+                "#EndRegion 'SUFFIX'"
+            }
+            $null = $merge.AppendFormat('{0}{1}', ($Suffix | Out-String), $Separator)
+        }
+
+        $null = $merge.Insert(0, ($usingList | Sort-Object | Get-Unique | Out-String))
+        Write-Verbose "Writing content to $RootModule"
+        # BUGBUG: Note that the encoding value *MUST* be in quotes for PowerShell 6
+        $merge.ToString() | Set-Content -Path $RootModule -Encoding "$($ModuleInfo.Encoding)"
+    } 
+}

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -184,55 +184,7 @@ function Build-Module {
             $ModuleInfo | CopyReadMe
 
             Write-Verbose "Combine scripts to $RootModule"
-            # Prefer pipeline to speed for the sake of memory and file IO
-            # SilentlyContinue because there don't *HAVE* to be functions at all
-
-            $AllScripts = Get-ChildItem -Path $SourceDirectories.ForEach{ Join-Path $ModuleInfo.ModuleBase $_ } -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue
-
-            & {
-                begin {
-                    if ($ModuleInfo.Prefix) {
-                        if (Test-Path $ModuleInfo.Prefix) {
-                            $SourceName = Resolve-Path $ModuleInfo.Prefix -Relative
-                            "#Region '$SourceName' 0"
-                            Get-Content $SourceName -OutVariable source
-                            "#EndRegion '$SourceName' $($Source.Count)"
-                        } else {
-                            "#Region 'PREFIX' 0"
-                            $ModuleInfo.Prefix
-                            "#EndRegion 'PREFIX'"
-                        }
-                    }
-                }
-                process {
-                    if ($AllScripts) {
-                        $AllScripts | ForEach-Object {
-                            $SourceName = Resolve-Path $_.FullName -Relative
-                            Write-Verbose "Adding $SourceName"
-                            "#Region '$SourceName' 0"
-                            Get-Content $SourceName
-                            "#EndRegion '$SourceName'"
-                        }
-                    }
-                }
-                end {
-                    if ($ModuleInfo.Suffix) {
-                        if (Test-Path $ModuleInfo.Suffix) {
-                            $SourceName = Resolve-Path $ModuleInfo.Suffix -Relative
-                            "#Region '$SourceName' 0"
-                            Get-Content $SourceName
-                            "#EndRegion '$SourceName'"
-                        } else {
-                            "#Region 'SUFFIX' 0"
-                            $ModuleInfo.Suffix
-                            "#EndRegion 'SUFFIX'"
-                        }
-                    }
-                }
-            } |
-            # BUGBUG: Note that the encoding value *MUST* be in quotes for PowerShell 6
-            Set-Content -Path $RootModule -Encoding "$($ModuleInfo.Encoding)"
-
+            MergeIntoModule -ModuleInfo $ModuleInfo -RootModule $RootModule
 
             # If there is a PublicFilter, update ExportedFunctions
             if ($ModuleInfo.PublicFilter) {


### PR DESCRIPTION
This extracts the merging scriptblock from `Build-Module` and does it a bit differently:

- it allows extracting `using` statements from the files and writes them at the top of the psm1
- It uses a String builder because I only write to file at the end, inserting the `Using` statements
- It still uses the Suffix/Prefix as defined by the $ModuleInfo object extended by Build-Module

You can use it in different ways:
```PowerShell
$AllScripts | MergeIntoModule -ModuleInfo $ModuleInfo -RootModule $RootModule
# or
MergeIntoModule -ModuleInfo $ModuleInfo -RootModule $RootModule 
# Will default to 
$AllScripts = Get-ChildItem -Path ("Enum", "Classes", "Private", "Public").ForEach{ Join-Path $ModuleInfo.ModuleBase $_ } -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue

# or 
MergeIntoModule -ModuleInfo $ModuleInfo -RootModule $RootModule -SourceDirectories "Priv*","Pub*"
# will use $AllFiles such as
$AllScripts = Get-ChildItem -Path $SourceDirectories.ForEach{ Join-Path $ModuleInfo.ModuleBase $_ } -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue
```

Let me know what you think.