### PR TITLE
Changed the regex for the region

### DIFF
--- a/Tests/Convert-LineNumber.Tests.ps1
+++ b/Tests/Convert-LineNumber.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Convert-LineNumber" {
         for($i=0; $i -lt 5; $i++) {
 
             $lineNumber = Get-Random -min 2 -max $ModuleSource.Count
-            while($ModuleSource[$lineNumber] -match "^# BEGIN") {
+            while($ModuleSource[$lineNumber] -match "^#REGION") {
                 $lineNumber++
             }
 


### PR DESCRIPTION
When running the Pester tests locally, it failed this test.
This fixes it