### PR TITLE
Fix Edit-Code

### DIFF
--- a/PotentialContribution/EditFunction.psm1
+++ b/PotentialContribution/EditFunction.psm1
@@ -361,6 +361,11 @@ function Edit-Code {
             if($File) {
                 $LastWriteTime = (Get-Item $File).LastWriteTime
 
+                # If it's a temp file, they're editing a function, so we have to wait!
+                if($File.EndsWith(".tmp.ps1") -and $File.StartsWith(([IO.Path]::GetTempPath()))) {
+                    $Wait = $true
+                }
+
                 # Avoid errors if Parameter is null/empty.
                 Write-Verbose "$PSEditor '$File'"
                 if ($PSEditor.Parameters)

--- a/PotentialContribution/EditFunction.psm1
+++ b/PotentialContribution/EditFunction.psm1
@@ -2,25 +2,33 @@
 
 # The EditFunction is going into the ModuleBuilder module...
 ## Version History:
+# 4.0 - Added support for VS Code, fixed a bug in the internal SplitCommand
 # 3.0 - made it work for file paths, and any script command. Added "edit" alias, and "NoWait" option.
 # 2.1 - fixed the fix: always remove temp file, persist across-sessions in environment
 # 2.0 - fixed persistence of editor options, made detection more clever
 # 1.1 - refactored by June to (also) work on her machine (and have help)
 # 1.0 - first draft, worked on my machine
 
-function Split-Command {
-    # The normal (unix) "Editor" environment variable can include parameters
-    # so it can be executed from command by just appending the file name.
-    # However, PowerShell can't deal with that, so:
+function SplitCommand {
+    <#
+        .SYNOPSIS
+            SplitCommand divides the input command into the executable command and the parameters
+        .DESCRIPTION
+            Start-Process needs the command name separate from the parameters
+
+            The normal (unix) "Editor" environment variable (or the one in `git config core.editor`)
+            can include parameters so it can be executed by just appending the file name.
+    #>
     param(
+        # The Editor command from the environment, like 'code -n -w'
         [Parameter(Mandatory=$true)]
         [string]$Command
     )
     $Parts = @($Command -Split " ")
 
-    for($count=$Parts.Length; $count -gt 1; $count--) {
+    for ($count=0; $count -lt $Parts.Length; $count++) {
         $Editor = ($Parts[0..$count] -join " ").Trim("'",'"')
-        if((Test-Path $Editor) -and (Get-Command $Editor -ErrorAction Ignore)) {
+        if (Get-Command $Editor -ErrorAction Ignore) {
             $Editor
             $Parts[$($Count+1)..$($Parts.Length)] -join " "
             break
@@ -32,9 +40,11 @@ function Find-Editor {
     #.Synopsis
     #   Find a simple code editor
     #.Description
-    #   Tries to find a text editor based on the PSEditor preference variable, the EDITOR environment variable, or your configuration for git.  As a fallback it searches for Sublime, Notepad++, or Atom, and finally falls back to Notepad.
+    #   Tries to find a text editor based on the PSEditor preference variable, the EDITOR environment variable, or your configuration for git.
+    #   As a fallback it searches for Sublime, VSCode, Atom, or Notepad++, and finally falls back to Notepad.
     #
-    #   I have deliberately excluded PowerShell_ISE because it is a single-instance app which doesn't support "wait" if it's already running.  That is, if PowerShell_ISE is already running, issuing a command like this will return immediately:
+    #   I have deliberately excluded PowerShell_ISE because it is a single-instance app which doesn't support "wait" if it's already running.
+    #   That is, if PowerShell_ISE is already running, issuing a command like this will return immediately:
     #
     #   Start-Process PowerShell_ISE $Profile -Wait
     [CmdletBinding()]
@@ -44,10 +54,16 @@ function Find-Editor {
         # Defaults to the value of $PSEditor.Command or $PSEditor or Env:Editor if any of them are set.
         [Parameter(Position=1)]
         [System.String]
-        $Editor = $(if($global:PSEditor.Command){ $global:PSEditor.Command } else { $global:PSEditor } ),
+        $Editor = $(
+            if($global:PSEditor.Command){
+                $global:PSEditor.Command
+            } else {
+                $global:PSEditor
+            }
+        ),
 
         # Specifies commandline parameters for the editor.
-        # Edit-Function.ps1 passes these editor-specific parameters to the editor you select.
+        # Edit-Code.ps1 passes these editor-specific parameters to the editor you select.
         # For example, sublime uses -n -w to trigger a mode where closing the *tab* will return
         [Parameter(Position=2)]
         [System.String]
@@ -55,21 +71,21 @@ function Find-Editor {
     )
 
     end {
-        do { # This is the GOTO hack: use break to skip to the end once we find it:
+        do {# This is the GOTO hack: use break to skip to the end once we find it:
             # In this test, we let the Get-Command error leak out on purpose
             if($Editor -and (Get-Command $Editor)) { break }
 
             if ($Editor -and !(Get-Command $Editor -ErrorAction Ignore))
             {
                 Write-Verbose "Editor is not a valid command, split it:"
-                $Editor, $Parameters = Split-Command $Editor
+                $Editor, $Parameters = SplitCommand $Editor
                 if($Editor) { break }
             }
 
             if (Test-Path Env:Editor)
             {
                 Write-Verbose "Editor was not passed in, trying Env:Editor"
-                $Editor, $Parameters = Split-Command $Env:Editor
+                $Editor, $Parameters = SplitCommand $Env:Editor
                 if($Editor) { break }
             }
 
@@ -78,7 +94,7 @@ function Find-Editor {
             {
                 Write-Verbose "PSEditor and Env:Editor not found, searching git config"
                 if($CoreEditor = git config core.editor) {
-                    $Editor, $Parameters = Split-Command $CoreEditor
+                    $Editor, $Parameters = SplitCommand $CoreEditor
                     if($Editor) { break }
                 }
             }
@@ -92,10 +108,12 @@ function Find-Editor {
             }
             if($Editor = Get-Command "code.cmd", "code-insiders" -ErrorAction Ignore | Select-Object -Expand Path -first 1)
             {
+                $Parameters = "-n -w"
                 break
             }
             if($Editor = Get-Command "atom.exe" -ErrorAction Ignore | Select-Object -Expand Path -first 1)
             {
+                $Parameters = "-n -w"
                 break
             }
             if($Editor = Get-Command "notepad++.exe" -ErrorAction Ignore | Select-Object -Expand Path -first 1)
@@ -105,7 +123,7 @@ function Find-Editor {
             }
             # Search the slow way for sublime
             Write-Verbose "Editor still not found, getting desperate:"
-            if(($Editor = Get-Item "C:\Program Files\DevTools\Sublime Text ?\sublime_text.exe" -ErrorAction Ignore | Sort {$_.VersionInfo.FileVersion} -Descending | Select-Object -First 1) -or
+            if(($Editor = Get-Item "C:\Program Files\Sublime Text ?\sublime_text.exe" -ErrorAction Ignore | Sort {$_.VersionInfo.FileVersion} -Descending | Select-Object -First 1) -or
                ($Editor = Get-ChildItem C:\Program*\* -recurse -filter "sublime_text.exe" -ErrorAction Ignore | Select-Object -First 1))
             {
                 $Parameters = "-n -w"
@@ -159,32 +177,31 @@ function Find-Editor {
 function Edit-Code {
     <#
         .SYNOPSIS
-            Creates and edits functions (or scripts) in the session in a script editor.
-
+            Opens folders, files, or functions in your favorite code editor (configurable)
 
         .DESCRIPTION
-            The Edit-Function command lets you create or edit functions in your session in your favorite text editor.
+            The Edit-Code command lets you open a folder, a file, or even a script function from your session in your favorite text editor.
 
             It opens the specified function in the editor that you specify, and when you finish editing the function and close the editor, the script updates the function in your session with the new function code.
 
-            Functions are tricky to edit, because most code editors require a file, and determine syntax highlighting based on the extension of that file. Edit-Function creates a temporary file with the function code.
+            Functions are tricky to edit, because most code editors require a file, and determine syntax highlighting based on the extension of that file. Edit-Code creates a temporary file with the function code.
 
             If you have a favorite editor, you can use the Editor parameter to specify it once, and the script will save it as your preference. If you don't specify an editor, it tries to determine an editor using the PSEditor preference variable, the EDITOR environment variable, or your configuration for git.  As a fallback it searches for Sublime, and finally falls back to Notepad.
 
             REMEMBER: Because functions are specific to a session, your function edits are lost when you close the session unless you save them in a permanent file, such as your Windows PowerShell profile.
 
         .EXAMPLE
-            Edit-Function Prompt
+            Edit-Code Prompt
 
             Opens the prompt function in a default editor (gitpad, Sublime, Notepad, whatever)
 
         .EXAMPLE
-            dir Function:\cd* | Edit-Function -Editor "C:\Program Files\Sublime Text 3\subl.exe" -Param "-n -w"
+            dir Function:\cd* | Edit-Code -Editor "C:\Program Files\Sublime Text 3\subl.exe" -Param "-n -w"
 
-            Pipes all functions starting with cd to Edit-Function, which opens them one at a time in a new sublime window (opens each one after the other closes).
+            Pipes all functions starting with cd to Edit-Code, which opens them one at a time in a new sublime window (opens each one after the other closes).
 
         .EXAMPLE
-            Get-Command TabExpan* | Edit-Function -Editor 'C:\Program Files\SAPIEN Technologies, Inc\PowerShell Studio 2014\PowerShell Studio.exe
+            Get-Command TabExpan* | Edit-Code -Editor 'C:\Program Files\SAPIEN Technologies, Inc\PowerShell Studio 2014\PowerShell Studio.exe
 
             Edits the TabExpansion and/or TabExpansion2 (whichever exists) in PowerShell Studio 2014 using the full path to the .exe file.
             Note that this also sets PowerShell Studio as your default editor for future calls.
@@ -197,29 +214,41 @@ function Edit-Code {
             - Think I should detect notepad2 or notepad++ or something?
 
             About ISE: it doesn't support waiting for the editor to close, sorry.
+            If you're sure you don't care about that, and want to use PowerShell ISE, you can set it in $PSEditor or pass it as a parameter.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess","")]
+    [Alias("edit")]
     [CmdletBinding(DefaultParameterSetName="Command")]
     param (
-        # Specifies the name of a function or script to create or edit. Enter a function name or pipe a function to Edit-Function.ps1. This parameter is required. If the function doesn't exist in the session, Edit-Function creates it.
+        # Specifies the name of a function or script to create or edit. Enter a function name or pipe a function to Edit-Code.
+        # This parameter is required. If the function doesn't exist in the session, Edit-Code creates it.
         [Parameter(Position=0, Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName="Command")]
         [Alias("PSPath")]
         [String]
         $Command,
 
-        # Specifies the name of a function or script to create or edit. Enter a function name or pipe a function to Edit-Function.ps1. This parameter is required. If the function doesn't exist in the session, Edit-Function creates it.
+        # Specifies the name of a function or script to create or edit. Enter a function name or pipe a function to Edit-Code.ps1.
+        # This parameter is required. If the function doesn't exist in the session, Edit-Code creates it.
         [Parameter(Mandatory = $true, ParameterSetName="File", ValueFromPipelineByPropertyName = $true)]
         [String[]]
         $Path,
 
-        # Specifies a code editor. If the editor is in the Path environment variable (Get-Command <editor>), you can enter just the editor name. Otherwise, enter the path to the executable file for the editor.
+        # Specifies a code editor.
+        # If the editor is in the Path environment variable (Get-Command <editor>), you can enter just the editor name.
+        # Otherwise, enter the path to the executable file for the editor.
         # Defaults to the value of $PSEditor.Command or $PSEditor or Env:Editor if any of them are set.
         [Parameter(Position=1)]
         [String]
-        $Editor = $(if($global:PSEditor.Command){ $global:PSEditor.Command } else { $global:PSEditor } ),
+        $Editor = $(
+            if ($global:PSEditor.Command) {
+                $global:PSEditor.Command
+            } else {
+                $global:PSEditor
+            }
+        ),
 
         # Specifies commandline parameters for the editor.
-        # Edit-Function.ps1 passes these editor-specific parameters to the editor you select.
+        # Edit-Code.ps1 passes these editor-specific parameters to the editor you select.
         # For example, sublime uses -n -w to trigger a mode where closing the *tab* will return
         [Parameter(Position=2)]
         [String]
@@ -235,7 +264,7 @@ function Edit-Code {
         [Switch]$Force
     )
     begin {
-        # This is a terrible idea ...
+        # This is probably a terrible idea ...
         $TextApplications  = ".cmd",".bat",".vbs",".pl",".rb",".py",".wsf",".js",".ps1"
         $NonFileCharacters = "[$(([IO.Path]::GetInvalidFileNameChars() | %{ [regex]::escape($_) }) -join '|')]"
 
@@ -336,11 +365,11 @@ function Edit-Code {
                 Write-Verbose "$PSEditor '$File'"
                 if ($PSEditor.Parameters)
                 {
-                    Start-Process -FilePath $PSEditor.Command -ArgumentList $PSEditor.Parameters, """$file""" -Wait:($Wait)
+                    Start-Process -FilePath $PSEditor.Command -ArgumentList $PSEditor.Parameters, """$file""" -Wait:($Wait) -NoNewWindow
                 }
                 else
                 {
-                    Start-Process -FilePath $PSEditor.Command -ArgumentList """$file""" -Wait:($Wait)
+                    Start-Process -FilePath $PSEditor.Command -ArgumentList """$file""" -Wait:($Wait) -NoNewWindow
                 }
 
                 # Remove it if we created it
@@ -362,5 +391,4 @@ function Edit-Code {
     }
 }
 
-Set-Alias edit Edit-Code
 Export-ModuleMember -Function Edit-Code, Find-Editor -Alias edit


### PR DESCRIPTION
Fixes #26 by fixing the split-command function, **and** adding `-n -w` to code's parameters by default, **and** forcing the use of `-Wait` when editing functions (I had to add -NoNewWindow to prevent the `atom` or `code` shell scripts from showing consoles).

It might be easier to get rid of the `Start-Process`  in here, but since it seems to work as desired, I'm leaving it.