### PR TITLE
Adding Feature to gather the Using statements at the top of the PSM1

### DIFF
--- a/Source/Private/MoveUsingStatements.ps1
+++ b/Source/Private/MoveUsingStatements.ps1
@@ -39,7 +39,8 @@ function MoveUsingStatements {
         Write-Debug "No Using Statement Error found."
         return
     }
-    elseif ($ParseError.Where{$_.ErrorId -ne 'UsingMustBeAtStartOfScript'}) {
+    # Avoid modifying the file if there's other parsing errors than Using Statements misplaced
+    if ($ParseError.Where{$_.ErrorId -ne 'UsingMustBeAtStartOfScript'}) {
         Write-Warning "Parsing errors found. Skipping Moving Using statements."
         return
     }

--- a/Source/Private/MoveUsingStatements.ps1
+++ b/Source/Private/MoveUsingStatements.ps1
@@ -1,3 +1,4 @@
+Using namespace System.Io # To test Convert-lineNumer when module is merged
 function MoveUsingStatements {
     <#
         .SYNOPSIS

--- a/Source/Private/MoveUsingStatements.ps1
+++ b/Source/Private/MoveUsingStatements.ps1
@@ -1,0 +1,81 @@
+function MoveUsingStatements {
+    <#
+        .SYNOPSIS
+            A command to comment out and copy to the top of the file the Using Statements
+        .DESCRIPTION
+            When all files are merged together, the Using statements from individual files
+            don't  necessarily end up at the beginning of the PSM1, creating Parsing Errors.
+
+            This function uses AST to comment out those statements (to preserver line numbering)
+            and insert them (conserving order) at the top of the script.
+
+            Should the merged RootModule already have errors not related to the Using statements,
+            or no errors caused by misplaced Using statements, this steps is skipped.
+
+            If moving (comment & copy) the Using statements introduce parsing errors to the script,
+            those changes won't be applied to the file.
+    #>
+    [CmdletBinding()]
+    Param(
+        # Path to the PSM1 file to amend
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ValueFromPipeline)]
+        $RootModule,
+
+        # The encoding defaults to UTF8 (or UTF8NoBom on Core)
+        [Parameter(DontShow)]
+        [string]$Encoding = $(if ($IsCoreCLR) { "UTF8NoBom" } else { "UTF8" })
+    )
+
+    $ParseError = $null
+    $AST = [System.Management.Automation.Language.Parser]::ParseFile(
+        $RootModule,
+        [ref]$null,
+        [ref]$ParseError
+    )
+
+    # Avoid modifying the file if there's no Parsing Error caused by Using Statements or other errors
+    if (!$ParseError.Where{$_.ErrorId -eq 'UsingMustBeAtStartOfScript'}) {
+        Write-Debug "No Using Statement Error found."
+        return
+    }
+    elseif ($ParseError.Where{$_.ErrorId -ne 'UsingMustBeAtStartOfScript'}) {
+        Write-Warning "Parsing errors found. Skipping Moving Using statements."
+        return
+    }
+
+    # Find all Using statements including those non erroring (to conserve their order)
+    $UsingStatementExtents = $AST.FindAll(
+        {$Args[0] -is [System.Management.Automation.Language.UsingStatementAst]},
+        $false
+    ).Extent
+
+    # Edit the Script content by commenting out existing statements (conserving line numbering)
+    $ScriptText = $AST.Extent.Text
+    $InsertedCharOffset = 0
+    $StatementsToCopy = New-Object System.Collections.ArrayList
+    foreach ($UsingSatement in $UsingStatementExtents) {
+        $ScriptText = $ScriptText.Insert($UsingSatement.StartOffset + $InsertedCharOffset, '#')
+        $InsertedCharOffset++
+
+        # Keep track of unique statements we'll need to insert at the top
+        if (!$StatementsToCopy.Contains($UsingSatement.Text)) {
+            $null = $StatementsToCopy.Add($UsingSatement.Text)
+        }
+    }
+
+    $ScriptText = $ScriptText.Insert(0, ($StatementsToCopy -join "`r`n") + "`r`n")
+
+    # Verify we haven't introduced new Parsing errors
+    $null = [System.Management.Automation.Language.Parser]::ParseInput(
+        $ScriptText,
+        [ref]$null,
+        [ref]$ParseError
+    )
+
+    if ($ParseError) {
+        Write-Warning "Oops, it seems that we introduced parsing error(s) while moving the Using Statements. Cancelling changes."
+    }
+    else {
+        $null = Set-Content -Value $ScriptText -Path $RootModule -Encoding $Encoding
+    }
+}

--- a/Source/Private/MoveUsingStatements.ps1
+++ b/Source/Private/MoveUsingStatements.ps1
@@ -1,4 +1,3 @@
-Using namespace System.Io # To test Convert-lineNumer when module is merged
 function MoveUsingStatements {
     <#
         .SYNOPSIS

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -197,6 +197,7 @@ function Build-Module {
             $AllScripts = Get-ChildItem -Path $SourceDirectories.ForEach{ Join-Path $ModuleInfo.ModuleBase $_ } -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue
 
             SetModuleContent -Source (@($ModuleInfo.Prefix) + $AllScripts.FullName + @($ModuleInfo.Suffix)).Where{$_} -Output $RootModule -Encoding "$($ModuleInfo.Encoding)"
+            MoveUsingStatements -RootModule $RootModule -Encoding "$($ModuleInfo.Encoding)"
 
             # If there is a PublicFilter, update ExportedFunctions
             if ($ModuleInfo.PublicFilter) {

--- a/Tests/Private/MoveUsingStatements.Tests.ps1
+++ b/Tests/Private/MoveUsingStatements.Tests.ps1
@@ -1,0 +1,7 @@
+Describe "MoveUsingStatements" {
+    # Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
+
+    # It 'Should get the SourceFile and LineNumber from stack trace messages with modules' {
+    #     $Source = InModuleScope ModuleBuilder { }
+    # }
+}

--- a/Tests/Private/MoveUsingStatements.Tests.ps1
+++ b/Tests/Private/MoveUsingStatements.Tests.ps1
@@ -1,7 +1,83 @@
 Describe "MoveUsingStatements" {
-    # Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
-    # It 'Should get the SourceFile and LineNumber from stack trace messages with modules' {
-    #     $Source = InModuleScope ModuleBuilder { }
-    # }
+    Context "Necessary Parameters" {
+        $CommandInfo = InModuleScope ModuleBuilder { Get-Command MoveUsingStatements }
+
+        It 'has a mandatory RootModule parameter' {
+            $RootModule = $CommandInfo.Parameters['RootModule']
+            $RootModule | Should -Not -BeNullOrEmpty
+            $RootModule.Attributes.Where{$_ -is [Parameter]}.Mandatory | Should -be $true
+        }
+
+        It "has an optional string Encoding parameter" {
+            $Encoding = $CommandInfo.Parameters['Encoding']
+            $Encoding | Should -Not -BeNullOrEmpty
+            $Encoding.ParameterType | Should -Be ([String])
+            $Encoding.Attributes.Where{$_ -is [Parameter]}.Mandatory | Should -Be $False
+        }
+    }
+
+    Context "Moving Using Statements to the beginning of the file" {
+        $TestCases = @(
+            @{
+                TestCaseName = '2xUsingMustBeAtStartOfScript'
+                PSM1File     = "function x {`r`n}`r`n" +
+                                "Using namespace System.io`r`n`r`n" + #UsingMustBeAtStartOfScript
+                                "function y {`r`n}`r`n" +
+                                "Using namespace System.Drawing" #UsingMustBeAtStartOfScript
+                ErrorBefore  = 2
+                ErrorAfter   = 0
+            },
+            @{
+                TestCaseName = 'NoErrors'
+                PSM1File     = "Using namespace System.io`r`n`r`n" +
+                                "Using namespace System.Drawing`r`n"+
+                                "function x { `r`n}`r`n" +
+                                "function y { `r`n}`r`n"
+                ErrorBefore  = 0
+                ErrorAfter   = 0
+            },
+            @{
+                TestCaseName = 'NotValidPowerShell'
+                PSM1File     = "Using namespace System.io`r`n`r`n" +
+                                "function x { `r`n}`r`n" +
+                                "Using namespace System.Drawing`r`n"+ # UsingMustBeAtStartOfScript
+                                "function y { `r`n}`r`n}" # Extra } at the end
+                ErrorBefore  = 2
+                ErrorAfter   = 2
+            }
+        )
+
+        It 'Should succeed <TestCaseName> from <ErrorBefore> to <ErrorAfter> parsing errors' -TestCases $TestCases {
+            param($TestCaseName, $PSM1File, $ErrorBefore, $ErrorAfter)
+
+            $testModuleFile = "$TestDrive\MyModule.psm1"
+            Set-Content $testModuleFile -value $PSM1File -Encoding UTF8
+            # Before
+            $ErrorFound = $null
+            $null = [System.Management.Automation.Language.Parser]::ParseFile(
+                $testModuleFile,
+                [ref]$null,
+                [ref]$ErrorFound
+            )
+            $ErrorFound.Count | Should -be $ErrorBefore
+
+            # After
+            InModuleScope ModuleBuilder {
+                $testModuleFile = "$TestDrive\MyModule.psm1"
+                MoveUsingStatements -RootModule $testModuleFile
+            }
+            $null = [System.Management.Automation.Language.Parser]::ParseFile(
+                $testModuleFile,
+                [ref]$null,
+                [ref]$ErrorFound
+            )
+            $ErrorFound.Count | Should -be $ErrorAfter
+        }
+
+        It 'Should Not do anything when there are no parsing errors' {
+
+        }
+
+    }
 }

--- a/Tests/Public/Convert-CodeCoverage.Tests.ps1
+++ b/Tests/Public/Convert-CodeCoverage.Tests.ps1
@@ -30,6 +30,6 @@ Describe "Convert-CodeCoverage" {
         $SourceLocation = $PesterResults | Convert-CodeCoverage -SourceRoot $ModuleRoot
 
         $SourceLocation.SourceFile | Should -Be ".\Private\CopyReadme.ps1"
-        $SourceLocation.Line | Should -Be 24
+        $SourceLocation.Line | Should -Be 25
     }
 }

--- a/Tests/Public/Convert-CodeCoverage.Tests.ps1
+++ b/Tests/Public/Convert-CodeCoverage.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Convert-CodeCoverage" {
     $ModuleFiles = Get-ChildItem $ModuleRoot -File -Recurse -Filter *.ps1
     $ModuleSource = Get-Content $ModulePath
 
-    $lineNumber = Get-Random -min 2 -max $ModuleSource.Count
+    $lineNumber = Get-Random -min 3 -max $ModuleSource.Count
     while($ModuleSource[$lineNumber] -match "^#(END)?REGION") {
         $lineNumber += 5
     }
@@ -22,7 +22,7 @@ Describe "Convert-CodeCoverage" {
                     Function = 'CopyReadme'
                     # these are pipeline bound
                     File = $ModulePath
-                    Line = 25
+                    Line = 26 # 1 offset with the Using Statement introduced in MoveUsingStatements
                 }
             }
         }

--- a/Tests/Public/Convert-LineNumber.Tests.ps1
+++ b/Tests/Public/Convert-LineNumber.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Convert-LineNumber" {
     for($i=0; $i -lt 5; $i++) {
 
         # I don't know why I keep trying to do this using random numbers
-        $lineNumber = Get-Random -min 2 -max $ModuleSource.Count
+        $lineNumber = Get-Random -min 3 -max $ModuleSource.Count
         # but I have to keep avoiding the lines that don't make sense
         while($ModuleSource[$lineNumber] -match "^\s*$|^#(END)?REGION|^\s*function\s") {
             $lineNumber += 5
@@ -53,7 +53,7 @@ Describe "Convert-LineNumber" {
             Function = 'CopyReadme'
             # these are pipeline bound
             File = $ModulePath
-            Line = 25
+            Line = 26 # 1 offset with the Using Statement introduced in MoveUsingStatements
         }
 
         $SourceLocation = $PesterMiss | Convert-LineNumber -Passthru

--- a/Tests/Public/Convert-LineNumber.Tests.ps1
+++ b/Tests/Public/Convert-LineNumber.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Convert-LineNumber" {
 
         $SourceLocation = $PesterMiss | Convert-LineNumber -Passthru
         $SourceLocation.SourceFile | Should -Be ".\Private\CopyReadme.ps1"
-        $SourceLocation.SourceLineNumber | Should -Be 24
+        $SourceLocation.SourceLineNumber | Should -Be 25
         $SourceLocation.Function | Should -Be 'CopyReadme'
     }
 }


### PR DESCRIPTION
As discussed in #19 this PR allow to pull the using statements to the top of the psm1:
1. Without parsing individual ps1 files, but using AST on the merged PSM1 output
2. It will warn and skip if there are parsing errors other than Using statements not at the top
3. It will do nothing if there are no `Using` statements errors (i.e. No using statements, or used the `-Prefix` adequately)
4. It will back off it is detects it introduced parsing errors and won't modify the file
5. It maintains the line numbering
6. It removes duplicate `Using` statements & keep ordering


# Important Notes

In order to test the conservation of the line numbering via the tests you already provided I had to introduce a `Using` statement (which is not needed) in the function `MoveUsingStatements`, which means the module needs its own latest version to compile itself...

To make it work and pass the test I do the following:
1. comment-out the first line of `MoveUsingStatements.ps1` (the Using statement)
2. Compile using `.\build.ps1` (don't run the tests yet)
3. Import the built module
4. Un-comment  the first line of `MoveUsingStatements.ps1` (the Using statement)
5. Compile using `Build-Module`
6. The test should now pass
