### PR TITLE
Making the Build.psd1 non-mandatory

### DIFF
--- a/Tests/Private/InitializeBuild.Tests.ps1
+++ b/Tests/Private/InitializeBuild.Tests.ps1
@@ -27,11 +27,16 @@ Describe "InitializeBuild" {
     Mock Get-Module -ModuleName ModuleBuilder {
         [PSCustomObject]@{
             ModuleBase = "TestDrive:\Source\"
-            Author = "Test Manager"
-            Version = [Version]"1.0.0"
-            Name = "MyModule"
+            Author     = "Test Manager"
+            Version    = [Version]"1.0.0"
+            Name       = "MyModule"
             RootModule = "MyModule.psm1"
         }
+    }
+    Mock Join-Path -ParameterFilter {
+        $Resolve -eq $true
+    } -ModuleName ModuleBuilder {
+        Join-Path -Path $Path -ChildPath $ChildPath
     }
 
     Context "It collects the initial data" {


### PR DESCRIPTION
fixes #44

This is a small change in the InitializeBuild function.
We execute `Import-Metadata` **only** if a file is found at the expected location (using `-resolve` in `Join-Path`).

If the result of `Import-Metadata` is not an hashtable (i.e. if the PSD1 is empty), it will set the `$BuildInfo` to an empty hashtable so that the `$ParameterValues` can still be set.

Had to amend the InitializeBuild test slightly, to ignore the `-Resolve` and pass thru the Path anyway to process the Build as if the file existed.