### PR TITLE
using ModuleVersion instead of RequiredVersion in RequiredModules.psd…

### DIFF
--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -1,4 +1,4 @@
 @(
-    @{ ModuleName = "Configuration"; RequiredVersion = "1.3.1"}
-    @{ ModuleName = "Pester"; RequiredVersion = "4.4.0"}
+    @{ ModuleName = "Configuration"; ModuleVersion = "1.3.1"}
+    @{ ModuleName = "Pester"; ModuleVersion = "4.4.0"}
 )


### PR DESCRIPTION
fixes #42

Very quick update to let bootstrap use versions of `pester` or `configuration` already installed on system instead of forcing the install of old versions.