### PR TITLE
[do not merge] PoC for Build.psd1 outside Source

### DIFF
--- a/Source/build.psd1
+++ b/Source/build.psd1
@@ -1,6 +1,0 @@
-@{
-    Path = "ModuleBuilder.psd1"
-    OutputDirectory = "..\"
-    VersionedOutputDirectory = $true
-    CopyDirectories = @('en-US')
-}

--- a/build.ps1
+++ b/build.ps1
@@ -34,7 +34,7 @@ try {
     # Build new output
     $ParameterString = $PSBoundParameters.GetEnumerator().ForEach{ '-' + $_.Key + " '" + $_.Value + "'" } -join " "
     Write-Verbose "Build-Module Source\build.psd1 $($ParameterString) -Target CleanBuild"
-    ModuleBuilderBootstrap\Build-Module Source\build.psd1 @PSBoundParameters -Target CleanBuild -Passthru -OutVariable BuildOutput | Split-Path
+    ModuleBuilderBootstrap\Build-Module config\build.psd1 @PSBoundParameters -Target CleanBuild -Passthru -OutVariable BuildOutput | Split-Path
     Write-Verbose "Module build output in $(Split-Path $BuildOutput.Path)"
 
     # Clean up environment

--- a/config/build.psd1
+++ b/config/build.psd1
@@ -1,0 +1,6 @@
+@{
+    Path = "../Source/ModuleBuilder.psd1"
+    OutputDirectory = "..\"
+    VersionedOutputDirectory = $true
+    CopyDirectories = @('en-US')
+}


### PR DESCRIPTION
Illustration for #49
This is extreme case where the `build.psd1` is in a config folder under the repo's root, although I would not recommend that! (just for the sake of the example).

The idea is that if you call the function `Build-Module` explicitly targeting a `Build.psd1` in parameter `-SourcePath`. That is where the `$BuildInfo` will be imported from, if any.

By setting the `Path` key in the Module Build file, pointing to the actual ModuleManifest we're building, relative to the parent folder of `Build.psd1` we tell ModuleBuilder where is the module we're trying to build, and we resolve the Source folder from there (relative to Module Manifest, not Build File).

That PR is just a quick illustration for the discussion, I would shift a few things around to do some of the validation done in ResolveModuleSource...