### PR TITLE
Fix #40

### DIFF
--- a/Source/Private/InitializeBuild.ps1
+++ b/Source/Private/InitializeBuild.ps1
@@ -59,6 +59,7 @@ function InitializeBuild {
     # Finally, add all the information in the module manifest to the return object
     $ModuleInfo = Get-Module $BuildInfo.Path -ListAvailable -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -ErrorVariable Problems
 
+
     # If there are any problems that count, fail
     if ($Problems = $Problems.Where({$_.FullyQualifiedErrorId -notmatch $ErrorsWeIgnore})) {
         foreach ($problem in $Problems) {
@@ -69,6 +70,7 @@ function InitializeBuild {
 
     # Update the ModuleManifest with our build configuration
     $ModuleInfo = Update-Object -InputObject $ModuleInfo -UpdateObject $BuildInfo
+    $ModuleInfo = Update-Object -InputObject $ModuleInfo -UpdateObject @{ DefaultCommandPrefix = $ModuleInfo.Prefix; Prefix = "" }
 
     # Ensure the OutputDirectory makes sense (it's never blank anymore)
     if (![IO.Path]::IsPathRooted($ModuleInfo.OutputDirectory)) {

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -1,0 +1,12 @@
+#requires -Module ModuleBuilder
+
+Describe "Invoke-Build With Source1" {
+    Context "When we call Invoke-Build" {
+        $Output = Build-Module .\Source1\build.psd1 -Passthru
+
+        It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
+            [IO.Path]::ChangeExtension($Output.Path, "psm1") |
+                Should -Not -FileContentMatch '^Source$'
+        }
+    }
+}

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -2,7 +2,7 @@
 
 Describe "Invoke-Build With Source1" {
     Context "When we call Invoke-Build" {
-        $Output = Build-Module .\Source1\build.psd1 -Passthru
+        $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -Passthru
 
         It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
             [IO.Path]::ChangeExtension($Output.Path, "psm1") |

--- a/Tests/Integration/Source1/Public/Get-Source.ps1
+++ b/Tests/Integration/Source1/Public/Get-Source.ps1
@@ -1,0 +1,4 @@
+function Get-Source {
+    [CmdletBinding()]
+    param()
+}

--- a/Tests/Integration/Source1/Source1.psd1
+++ b/Tests/Integration/Source1/Source1.psd1
@@ -1,0 +1,55 @@
+@{
+    # The module version should be SemVer.org compatible
+    ModuleVersion          = "1.0.0"
+
+    # PrivateData is where all third-party metadata goes
+    PrivateData            = @{
+        # PrivateData.PSData is the PowerShell Gallery data
+        PSData             = @{
+            # Prerelease string should be here, so we can set it
+            Prerelease     = ''
+
+            # Release Notes have to be here, so we can update them
+            ReleaseNotes   = '
+            A test module
+            '
+
+            # Tags applied to this module. These help with module discovery in online galleries.
+            Tags           = 'Authoring','Build','Development','BestPractices'
+
+            # A URL to the license for this module.
+            LicenseUri     = 'https://github.com/PoshCode/ModuleBuilder/blob/master/LICENSE'
+
+            # A URL to the main website for this project.
+            ProjectUri     = 'https://github.com/PoshCode/ModuleBuilder'
+
+            # A URL to an icon representing this module.
+            IconUri        = 'https://github.com/PoshCode/ModuleBuilder/blob/resources/ModuleBuilder.png?raw=true'
+        } # End of PSData
+    } # End of PrivateData
+
+    # The main script module that is automatically loaded as part of this module
+    RootModule             = 'Source1.psm1'
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules        = @()
+
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    DefaultCommandPrefix = 'Source'
+
+    # Always define FunctionsToExport as an empty @() which will be replaced on build
+    FunctionsToExport      = @()
+
+    # ID used to uniquely identify this module
+    GUID                   = 'a264e183-e0f7-4219-bc80-c30d14e0e98e'
+    Description            = 'A module for authoring and building PowerShell modules'
+
+    # Common stuff for all our modules:
+    CompanyName            = 'PoshCode'
+    Author                 = 'Joel Bennett'
+    Copyright              = "Copyright 2018 Joel Bennett"
+
+    # Minimum version of the Windows PowerShell engine required by this module
+    PowerShellVersion      = '5.1'
+    CompatiblePSEditions = @('Core','Desktop')
+}

--- a/Tests/Integration/Source1/build.psd1
+++ b/Tests/Integration/Source1/build.psd1
@@ -1,0 +1,5 @@
+@{
+    Path                     = "Source1.psd1"
+    OutputDirectory          = "..\Result1"
+    VersionedOutputDirectory = $true
+}


### PR DESCRIPTION
PowerShell puts DefaultCommandPrefix as "Prefix" on the ModuleInfo
We want to use Prefix for something else
So we just move theirs back to DefaultCommandPrefix