### PR TITLE
changing to gitversion 4, and mode mainline

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,18 +1,21 @@
-mode: ContinuousDeployment
-next-version: 1.0.0
-assembly-versioning-scheme: 'MajorMinorPatchTag'
+assembly-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{NuGetVersionV2}+Sha.{Sha}.Date.{CommitDate}'
+mode: Mainline
+next-version: 1.0.0
 commit-message-incrementing: MergeMessageOnly
 branches:
-  develop:
-    tag: alpha
   master:
-    tag: beta
+    tag: preview
     increment: Minor
-  features?[/-]:
-    increment: Minor
-  releases?[/-]:
+  features:
+    increment: patch
+    regex: features?[/-]
+    source-branches:
+    - master
+  releases:
     increment: None
-
+    regex: releases?[/-]
+    source-branches:
+    - master
 ignore:
   sha: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pool:
   vmImage: 'VS2017-Win2016' #  options: 'Ubuntu 16.04', 'macOS 10.13', 'VS2017-Win2016'
 
 steps:
-- task: gittools.gitversion.gitversion-task.GitVersion@3
+- task: gittools.gitversion.gitversion-task.GitVersion@4
   displayName: GitVersion
 
 # As long as we're calling build.ps1, we don't need to bootstrap separately


### PR DESCRIPTION
I think the Mainline mode would work well for Trunk based dev as you do.
I think we should:
- build and pre-release every PR that you merge to master as a preview
- release main versions when upon tag

This simple PR is a way to open the discussion.
There's also a dotnet core task of GitVersion 4 that might have a different name, and we should probably use instead.