### PR TITLE
Fix not picking scripts from custom source directories

### DIFF
--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -194,7 +194,7 @@ function Build-Module {
             Write-Verbose "Combine scripts to $RootModule"
 
             # SilentlyContinue because there don't *HAVE* to be functions at all
-            $AllScripts = Get-ChildItem -Path $SourceDirectories.ForEach{ Join-Path $ModuleInfo.ModuleBase $_ } -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue
+            $AllScripts = Get-ChildItem -Path @($ModuleInfo.SourceDirectories).ForEach{ Join-Path $ModuleInfo.ModuleBase $_ } -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue
 
             SetModuleContent -Source (@($ModuleInfo.Prefix) + $AllScripts.FullName + @($ModuleInfo.Suffix)).Where{$_} -Output $RootModule -Encoding "$($ModuleInfo.Encoding)"
             MoveUsingStatements -RootModule $RootModule -Encoding "$($ModuleInfo.Encoding)"


### PR DESCRIPTION
As described in the issue #55 the list of source directories can't be changed in build.ps1.
This pull request fixes this issue.