### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig is awesome: http://EditorConfig.org
+#
+# Settings follow https://github.com/PowerShell/PowerShellEditorServices/blob/master/.editorconfig
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+insert_final_newline = true
+
+[*.{cs}]
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{json}]
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{ps1,psm1,psd1}]
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{ps1xml,props,xml,yaml}]
+indent_size = 2


### PR DESCRIPTION
This should prevent editors (like mine) from using non-repo defaults like adding newlines etc.