### PR TITLE
Fix #70 semver splitting

### DIFF
--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -70,18 +70,18 @@ function Build-Module {
         # The module version (must be a valid System.Version such as PowerShell supports for modules)
         [Alias("ModuleVersion")]
         [Parameter(ParameterSetName="ModuleVersion", Mandatory)]
-        [version]$Version = $(if($V = $SemVer.Split("+")[0].Split("-")[0]){$V}),
+        [version]$Version = $(if($V = $SemVer.Split("+")[0].Split("-",2)[0]){$V}),
 
         # Setting pre-release forces the release to be a pre-release.
         # Must be valid pre-release tag like PowerShellGet supports
         [Parameter(ParameterSetName="ModuleVersion")]
-        [string]$Prerelease = $($SemVer.Split("+")[0].Split("-")[1]),
+        [string]$Prerelease = $($SemVer.Split("+")[0].Split("-",2)[1]),
 
         # Build metadata (like the commit sha or the date).
         # If a value is provided here, then the full Semantic version will be inserted to the release notes:
         # Like: ModuleName v(Version(-Prerelease?)+BuildMetadata)
         [Parameter(ParameterSetName="ModuleVersion")]
-        [string]$BuildMetadata = $($SemVer.Split("+")[1]),
+        [string]$BuildMetadata = $($SemVer.Split("+",2)[1]),
 
         # Folders which should be copied intact to the module output
         # Can be relative to the  module folder

--- a/Source/build.psd1
+++ b/Source/build.psd1
@@ -2,7 +2,7 @@
 # command when building the module (see `Get-Help Build-Module -Full` for details).
 @{
     Path = "ModuleBuilder.psd1"
-    OutputDirectory = "../Output"
+    OutputDirectory = "../Output/ModuleBuilder"
     VersionedOutputDirectory = $true
     CopyDirectories = @('en-US')
 }

--- a/Tests/Public/Build-Module.Tests.ps1
+++ b/Tests/Public/Build-Module.Tests.ps1
@@ -460,10 +460,6 @@ Describe "Build-Module" {
         }
 
         Context "When I Build-Module -Version 1.2.3 -Prerelease pre-release" {
-            $SemVer = @{
-                Version    = "1.2.3"
-                Prerelease = "pre-release"
-            }
             It "Should set the prerelese to 'pre-release'" {
                 Mock Update-Metadata -ParameterFilter {
                     $PropertyName -eq "PrivateData.PSData.Prerelease"
@@ -472,7 +468,7 @@ Describe "Build-Module" {
                 } -ModuleName ModuleBuilder
 
                 try {
-                    Build-Module @SemVer -Verbose
+                    Build-Module -Version "1.2.3" -Prerelease "pre-release"
                 } catch {
                     throw
                 }
@@ -494,7 +490,7 @@ Describe "Build-Module" {
                 } -ModuleName ModuleBuilder
 
                 try {
-                    Build-Module -SemVer "1.2.3-pre-release" -Verbose
+                    Build-Module -SemVer "1.2.3-pre-release"
                 } catch {
                     throw
                 }

--- a/Tests/Public/Build-Module.Tests.ps1
+++ b/Tests/Public/Build-Module.Tests.ps1
@@ -413,4 +413,96 @@ Describe "Build-Module" {
 
         Pop-Location -StackName BuildModuleTest
     }
+
+    Context "Bug #70 Cannot build 1.2.3-pre-release" {
+        BeforeEach {
+            Push-Location TestDrive:\ -StackName BuildModuleTest
+            New-Item -ItemType Directory -Path TestDrive:\MyModule\ -Force
+            New-Item -ItemType Directory -Path "TestDrive:\$ExpectedVersion\" -Force
+
+            Mock SetModuleContent -ModuleName ModuleBuilder { }
+            Mock Update-Metadata -ModuleName ModuleBuilder { }
+
+            Mock InitializeBuild -ModuleName ModuleBuilder {
+                # These are actually all the values that we need
+                [PSCustomObject]@{
+                    OutputDirectory = "TestDrive:\$Version"
+                    Name            = "MyModule"
+                    ModuleBase      = "TestDrive:\MyModule\"
+                    CopyDirectories = @()
+                    Encoding        = "UTF8"
+                    PublicFilter    = "Public\*.ps1"
+                }
+            }
+
+            Mock New-Item { [IO.FileInfo](Join-Path (Convert-Path "TestDrive:\") $ExpectedVersion) } -Parameter {
+                $Path -eq "TestDrive:\$ExpectedVersion" -and
+                $ItemType -eq "Directory" -and
+                $Force -eq $true
+            } -ModuleName ModuleBuilder
+
+            Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:\$ExpectedVersion" } -ModuleName ModuleBuilder
+            Mock Remove-Item { } -Parameter { $Path.StartsWith((Convert-Path "TestDrive:\$ExpectedVersion")) } -ModuleName ModuleBuilder
+            Mock Set-Location { } -ModuleName ModuleBuilder
+            Mock Copy-Item { } -ModuleName ModuleBuilder
+            # Release notes
+            Mock Get-Metadata { "First Release" } -ModuleName ModuleBuilder
+            Mock Join-Path {
+                [IO.Path]::Combine($Path, $ChildPath)
+            } -ModuleName ModuleBuilder
+
+            Mock Get-ChildItem {
+                [IO.FileInfo]$(Join-Path $(Convert-Path "TestDrive:\") "MyModule\Public\Get-MyInfo.ps1")
+            } -ModuleName ModuleBuilder
+        }
+        AfterEach {
+            Pop-Location -StackName BuildModuleTest
+        }
+
+        Context "When I Build-Module -Version 1.2.3 -Prerelease pre-release" {
+            $SemVer = @{
+                Version    = "1.2.3"
+                Prerelease = "pre-release"
+            }
+            It "Should set the prerelese to 'pre-release'" {
+                Mock Update-Metadata -ParameterFilter {
+                    $PropertyName -eq "PrivateData.PSData.Prerelease"
+                } -MockWith {
+                    $Value | Should -Be "pre-release"
+                } -ModuleName ModuleBuilder
+
+                try {
+                    Build-Module @SemVer -Verbose
+                } catch {
+                    throw
+                }
+
+                Assert-MockCalled Update-Metadata -ParameterFilter {
+                    $PropertyName -eq "PrivateData.PSData.Prerelease" -and $Value -eq "pre-release"
+                } -ModuleName ModuleBuilder
+            }
+        }
+
+
+        Context "When I Build-Module -SemVer 1.2.3-pre-release" {
+
+            It "Should set the prerelese to 'pre-release'" {
+                Mock Update-Metadata -ParameterFilter {
+                    $PropertyName -eq "PrivateData.PSData.Prerelease"
+                } -MockWith {
+                    $Value | Should -Be "pre-release"
+                } -ModuleName ModuleBuilder
+
+                try {
+                    Build-Module -SemVer "1.2.3-pre-release" -Verbose
+                } catch {
+                    throw
+                }
+
+                Assert-MockCalled Update-Metadata -ParameterFilter {
+                    $PropertyName -eq "PrivateData.PSData.Prerelease" -and $Value -eq "pre-release"
+                } -ModuleName ModuleBuilder
+            }
+        }
+    }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -16,6 +16,13 @@ param(
 # Sanitize parameters to pass to Build-Module
 $null = $PSBoundParameters.Remove('Test')
 
+if (-not $Semver) {
+    if ($semver = gitversion -showvariable SemVer) {
+        $null = $PSBoundParameters.Add("SemVer", $SemVer)
+    }
+}
+
+
 $ErrorActionPreference = "Stop"
 Push-Location $PSScriptRoot -StackName BuildBuildModule
 try {


### PR DESCRIPTION
This bug only actually affected you when you had a pre-release label with a hyphen in it, **and** you pass it as part of -SemVer instead of separating it yourself (most of our tests pass it separately).

I added a passing and failing test to show the problem, then fixed it in the parameter binding.