### PR TITLE
Fix exporting multiple aliases for a single command

### DIFF
--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -219,7 +219,7 @@ function Build-Module {
             $ParseResult | MoveUsingStatements -Encoding "$($ModuleInfo.Encoding)"
 
             if ($PublicFunctions -and -not $ModuleInfo.IgnoreAliasAttribute) {
-                if (($AliasesToExport = ($ParseResult | GetCommandAlias)[$PublicFunctions] | Select-Object -Unique)) {
+                if (($AliasesToExport = ($ParseResult | GetCommandAlias)[$PublicFunctions] | ForEach-Object { $_ } | Select-Object -Unique)) {
                     Update-Metadata -Path $OutputManifest -PropertyName AliasesToExport -Value $AliasesToExport
                 }
             }

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -12,11 +12,11 @@ Describe "Build-Module With Source1" {
         $Metadata = Import-Metadata $Output.Path
 
         It "Should update FunctionsToExport in the manifest" {
-            $Metadata.FunctionsToExport | Should -Be @("Get-Source")
+            $Metadata.FunctionsToExport | Should -Be @("Get-Source", "Set-Source")
         }
 
         It "Should update AliasesToExport in the manifest" {
-            $Metadata.AliasesToExport | Should -Be @("GS")
+            $Metadata.AliasesToExport -match "GS" | Should -Not -BeNullOrEmpty
         }
 
         It "Should de-dupe and move using statements to the top of the file" {
@@ -76,5 +76,17 @@ Describe "Build-Module With Source1" {
         It "Will comment out the original using statement in the original positions" {
             (Select-String -Pattern "^#\s*using" -Path $Module).Count | Should -Be 2
         }
+    }
+
+    Context "Regression test for #84: Multiple Aliases per command will Export" {
+        $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -Passthru
+        $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
+
+        $Metadata = Import-Metadata $Output.Path
+
+        It "Should update AliasesToExport in the manifest" {
+            $Metadata.AliasesToExport | Should -Be @("GS","GSou", "SS", "SSou")
+        }
+
     }
 }

--- a/Tests/Integration/Source1/Public/Get-Source.ps1
+++ b/Tests/Integration/Source1/Public/Get-Source.ps1
@@ -2,6 +2,6 @@ using module ModuleBuilder
 
 function Get-Source {
     [CmdletBinding()]
-    [Alias("gs")]
+    [Alias("gs","gsou")]
     param()
 }

--- a/Tests/Integration/Source1/Public/Set-Source.ps1
+++ b/Tests/Integration/Source1/Public/Set-Source.ps1
@@ -1,0 +1,5 @@
+function Set-Source {
+    [CmdletBinding()]
+    [Alias("ss", "ssou")]
+    param()
+}


### PR DESCRIPTION
We unroll the alias array and fix the export.
Added a regression test to verify the fix