### PR TITLE
Make build.psd1 optional and fix bugs in 1.5.2

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,10 @@
                 "isDefault": true
             },
             "type": "shell",
-            "command": "${workspaceFolder}\\build.ps1",
+            "command": "${workspaceFolder}/build.ps1",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
             "presentation": {
                 "echo": true,
                 "reveal": "silent",
@@ -27,18 +30,10 @@
                 "isDefault": true
             },
             "type": "shell",
+            "command": "${workspaceFolder}/test.ps1",
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PSModulePath": "${workspaceFolder}\\Output;${env:PSModulePath}"
-                }
             },
-            "command": "Invoke-Pester",
-            "args": [
-                "${workspaceFolder}\\Tests",
-                "-PesterOption", "@{ IncludeVSCodeMarker = $True }",
-                "-CodeCoverage", "${workspaceFolder}\\Output\\*.psm1"
-            ],
             "presentation": {
                 "echo": true,
                 "reveal": "always",

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -98,12 +98,15 @@ For best results, you need to organize your module project similarly to how this
 
 1. Create a `source` folder with a `build.psd1` file and your module manifest in it
 2. In the `build.psd1` specify the relative **Path** to your module's manifest, e.g. `@{ Path = "ModuleBuilder.psd1" }`
-3. In your manifest, make sure the `FunctionsToExport` entry is not commented out. You can leave it empty
+3. In your manifest, make sure a few values are not commented out. You can leave them empty, because they'll be overwritten:
+    - `FunctionsToExport` will be updated with the _file names_ that match the `PublicFilter`
+    - `AliasesToExport` will be updated with the values from `[Alias()]` attributes on commands
+    - `Prerelease` and `ReleaseNotes` in the `PSData` hashtable in `PrivateData`
 
 Once you start working on the module, you'll create sub-folders in source, and put script files in them with only **one** function in each file. You should name the files with _the same name_ as the function that's in them -- especially in the public folder, where we use the file name (without the extension) to determine the exported functions.
 
 1. By convention, use folders named "Classes" (and/or "Enum"), "Private", and "Public"
-2. By convention, the functions in "Public" will be exported from the module
+2. By convention, the functions in "Public" will be exported from the module (you can override the `PublicFilter`)
 3. To force classes to be in a certain order, you can prefix their file names with numbers, like `01-User.ps1`
 
 There are a *lot* of conventions in `Build-Module`, expressed as default values for its parameters. These defaults are documented in the help for Build-Module. You can override any parameter to `Build-Module` by passing it, or by adding keys to the `build.psd1` file with your preferences.

--- a/Source/Private/ImportModuleManifest.ps1
+++ b/Source/Private/ImportModuleManifest.ps1
@@ -1,0 +1,36 @@
+function ImportModuleManifest {
+    [CmdletBinding()]
+    param(
+        [Alias("PSPath")]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string]$Path
+    )
+    process {
+        # Get all the information in the module manifest
+        $ModuleInfo = Get-Module $Path -ListAvailable -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -ErrorVariable Problems
+
+        # Some versions fails silently. If the GUID is empty, we didn't get anything at all
+        if ($ModuleInfo.Guid -eq [Guid]::Empty) {
+            Write-Error "Cannot parse '$Path' as a module manifest, try Test-ModuleManifest for details"
+            return
+        }
+
+        # Some versions show errors are when the psm1 doesn't exist (yet), but we don't care
+        $ErrorsWeIgnore = "^" + (@(
+            "Modules_InvalidRequiredModulesinModuleManifest"
+            "Modules_InvalidRootModuleInModuleManifest"
+        ) -join "|^")
+
+        # If there are any OTHER problems we'll fail
+        if ($Problems = $Problems.Where({ $_.FullyQualifiedErrorId -notmatch $ErrorsWeIgnore })) {
+            foreach ($problem in $Problems) {
+                Write-Error $problem
+            }
+            # Short circuit - don't output the ModuleInfo if there were errors
+            return
+        }
+
+        # Workaround the fact that Get-Module returns the DefaultCommandPrefix as Prefix
+        Update-Object -InputObject $ModuleInfo -UpdateObject @{ DefaultCommandPrefix = $ModuleInfo.Prefix; Prefix = "" }
+    }
+}

--- a/Source/Private/InitializeBuild.ps1
+++ b/Source/Private/InitializeBuild.ps1
@@ -26,7 +26,11 @@ function InitializeBuild {
     # GetBuildInfo reads the parameter values from the Build-Module command and combines them with the Manifest values
     $BuildManifest = ResolveBuildManifest $SourcePath
 
-    Write-Debug "BuildCommand: $($BuildCommandInvocation.MyCommand | Out-String)"
+    Write-Debug "BuildCommand: $(
+        @(
+            @($BuildCommandInvocation.MyCommand.Name)
+            @($BuildCommandInvocation.BoundParameters.GetEnumerator().ForEach{ "-{0} '{1}'" -f $_.Key, $_.Value })
+        ) -join ' ')"
     $BuildInfo = GetBuildInfo -BuildManifest $BuildManifest -BuildCommandInvocation $BuildCommandInvocation
 
     # Finally, add all the information in the module manifest to the return object

--- a/Source/Private/InitializeBuild.ps1
+++ b/Source/Private/InitializeBuild.ps1
@@ -36,7 +36,7 @@ function InitializeBuild {
     ) -join "|^"
 
     # Finally, add all the information in the module manifest to the return object
-    $ModuleInfo = Get-Module (Get-Item $BuildInfo.ModuleManifest).FullName -ListAvailable -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -ErrorVariable Problems
+    $ModuleInfo = Get-Module (Get-Item $BuildInfo.SourcePath).FullName -ListAvailable -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -ErrorVariable Problems
 
     # If there are any problems that count, fail
     if ($Problems = $Problems.Where({ $_.FullyQualifiedErrorId -notmatch $ErrorsWeIgnore })) {

--- a/Source/Private/InitializeBuild.ps1
+++ b/Source/Private/InitializeBuild.ps1
@@ -39,14 +39,14 @@ function InitializeBuild {
     $ModuleInfo = Get-Module (Get-Item $BuildInfo.ModuleManifest).FullName -ListAvailable -WarningAction SilentlyContinue -ErrorAction SilentlyContinue -ErrorVariable Problems
 
     # If there are any problems that count, fail
-    if ($Problems = $Problems.Where( {$_.FullyQualifiedErrorId -notmatch $ErrorsWeIgnore})) {
+    if ($Problems = $Problems.Where({ $_.FullyQualifiedErrorId -notmatch $ErrorsWeIgnore })) {
         foreach ($problem in $Problems) {
             Write-Error $problem
         }
         throw "Unresolvable problems in module manifest"
     }
 
-    # Update the ModuleManifest with our build configuration
+    # Update the module manifest with our build configuration
     $ModuleInfo = Update-Object -InputObject $ModuleInfo -UpdateObject $BuildInfo
     $ModuleInfo = Update-Object -InputObject $ModuleInfo -UpdateObject @{ DefaultCommandPrefix = $ModuleInfo.Prefix; Prefix = "" }
 

--- a/Source/Private/InitializeBuild.ps1
+++ b/Source/Private/InitializeBuild.ps1
@@ -46,9 +46,10 @@ function InitializeBuild {
         throw "Unresolvable problems in module manifest"
     }
 
+    # Workaround the fact that Get-Module returns the DefaultCommandPrefix as Prefix
+    $ModuleInfo = Update-Object -InputObject $ModuleInfo -UpdateObject @{ DefaultCommandPrefix = $ModuleInfo.Prefix; Prefix = "" }
     # Update the module manifest with our build configuration
     $ModuleInfo = Update-Object -InputObject $ModuleInfo -UpdateObject $BuildInfo
-    $ModuleInfo = Update-Object -InputObject $ModuleInfo -UpdateObject @{ DefaultCommandPrefix = $ModuleInfo.Prefix; Prefix = "" }
 
     $ModuleInfo
 }

--- a/Source/Private/MoveUsingStatements.ps1
+++ b/Source/Private/MoveUsingStatements.ps1
@@ -32,12 +32,12 @@ function MoveUsingStatements {
 
     # Avoid modifying the file if there's no Parsing Error caused by Using Statements or other errors
     if (!$ParseErrors.Where{$_.ErrorId -eq 'UsingMustBeAtStartOfScript'}) {
-        Write-Debug "No Using Statement Error found."
+        Write-Debug "No using statement errors found."
         return
     }
     # Avoid modifying the file if there's other parsing errors than Using Statements misplaced
     if ($ParseErrors.Where{$_.ErrorId -ne 'UsingMustBeAtStartOfScript'}) {
-        Write-Warning "Parsing errors found. Skipping Moving Using statements."
+        Write-Warning "Parsing errors found. Skipping moving using statements."
         return
     }
 
@@ -71,9 +71,8 @@ function MoveUsingStatements {
     )
 
     if ($ParseErrors) {
-        Write-Warning "Oops, it seems that we introduced parsing error(s) while moving the Using Statements. Cancelling changes."
-    }
-    else {
+        Write-Warning "We introduced parsing error(s) while attempting to move using statements. Cancelling changes."
+    } else {
         $null = Set-Content -Value $ScriptText -Path $RootModule -Encoding $Encoding
     }
 }

--- a/Source/Private/ResolveBuildManifest.ps1
+++ b/Source/Private/ResolveBuildManifest.ps1
@@ -9,7 +9,7 @@ function ResolveBuildManifest {
     if ((Split-Path $SourcePath -Leaf) -eq 'build.psd1') {
         $BuildManifest = $SourcePath
     } elseif (Test-Path $SourcePath -PathType Leaf) {
-        # When you pass the ModuleManifest as parameter, you must have the Build Manifest in the same folder
+        # When you pass the SourcePath as parameter, you must have the Build Manifest in the same folder
         $BuildManifest = Join-Path (Split-Path -Parent $SourcePath) [Bb]uild.psd1
     } else {
         # It's a container, assume the Build Manifest is directly under
@@ -19,9 +19,7 @@ function ResolveBuildManifest {
     # Make sure we are resolving the absolute path to the manifest, and test it exists
     $ResolvedBuildManifest = (Resolve-Path $BuildManifest -ErrorAction SilentlyContinue).Path
 
-    if (-Not ($ResolvedBuildManifest)) {
-        throw "Couldn't resolve the Build Manifest at $BuildManifest"
-    } else {
+    if ($ResolvedBuildManifest) {
         $ResolvedBuildManifest
     }
 

--- a/Source/Private/SetModuleContent.ps1
+++ b/Source/Private/SetModuleContent.ps1
@@ -31,6 +31,7 @@ function SetModuleContent {
         [string]$Encoding = $(if($IsCoreCLR) { "UTF8Bom" } else { "UTF8" })
     )
     begin {
+        Write-Debug "SetModuleContent WorkingDirectory $WorkingDirectory"
         Push-Location $WorkingDirectory -StackName SetModuleContent
         $ContentStarted = $false # There has been no content yet
 

--- a/Source/build.psd1
+++ b/Source/build.psd1
@@ -1,7 +1,7 @@
 # Use this file to override the default parameter values used by the `Build-Module`
 # command when building the module (see `Get-Help Build-Module -Full` for details).
 @{
-    Path = "ModuleBuilder.psd1"
+    ModuleManifest  = "ModuleBuilder.psd1"
     # Subsequent relative paths are to the ModuleManifest
     OutputDirectory = "../"
     VersionedOutputDirectory = $true

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -86,6 +86,39 @@ Describe "Build-Module With Source1" {
         It "Should update AliasesToExport in the manifest" {
             $Metadata.AliasesToExport | Should -Be @("GS","GSou", "SS", "SSou")
         }
+    }
+
+    Context "Supports building without a build.psd1" {
+        Copy-Item  $PSScriptRoot\Source1 $PSScriptRoot\Copy1 -Recurse
+        Remove-Item $PSScriptRoot\Copy1\build.psd1
+        Rename-Item $PSScriptRoot\Copy1\Source1.psd1 Copy1.psd1
+
+        $Build = @{ }
+
+        It "No longer fails if there's no build.psd1" {
+            $BuildParameters = @{
+                SourcePath               = "$PSScriptRoot\Copy1\Copy1.psd1"
+                OutputDirectory          = "..\Result1"
+                VersionedOutputDirectory = $true
+            }
+
+            $Build.Output = Build-Module @BuildParameters -Passthru
+        }
+
+        Remove-Item -Recurse $PSScriptRoot\Copy1
+
+
+        It "Creates the same module as with a build.psd1" {
+            $Build.Metadata = Import-Metadata $Build.Output.Path
+        }
+
+        It "Should update AliasesToExport in the manifest" {
+            $Build.Metadata.AliasesToExport | Should -Be @("GS", "GSou", "SS", "SSou")
+        }
+
+        It "Should update FunctionsToExport in the manifest" {
+            $Build.Metadata.FunctionsToExport | Should -Be @("Get-Source", "Set-Source")
+        }
 
     }
 }

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -80,7 +80,6 @@ Describe "Build-Module With Source1" {
 
     Context "Regression test for #84: Multiple Aliases per command will Export" {
         $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -Passthru
-        $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
 
         $Metadata = Import-Metadata $Output.Path
 

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -1,124 +1,133 @@
 #requires -Module ModuleBuilder
 
-Describe "Build-Module With Source1" {
-    Context "When we call Build-Module" {
-        $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -Passthru
+Describe "When we call Build-Module" -Tag Integration {
+    $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -Passthru
+    $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
+
+    It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
+        $Module | Should -Not -FileContentMatch '^Source$'
+    }
+
+    $Metadata = Import-Metadata $Output.Path
+
+    It "Should update FunctionsToExport in the manifest" {
+        $Metadata.FunctionsToExport | Should -Be @("Get-Source", "Set-Source")
+    }
+
+    It "Should update AliasesToExport in the manifest" {
+        $Metadata.AliasesToExport -match "GS" | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should de-dupe and move using statements to the top of the file" {
+        Select-String -Pattern "^using" -Path $Module | ForEach-Object LineNumber | Should -Be 1
+    }
+
+    It "Will comment out the original using statements in their original positions" {
+        (Select-String -Pattern "^#\s*using" -Path $Module).Count | Should -Be 3
+    }
+}
+
+Describe "Regression test for #55: I can pass SourceDirectories" -Tag Integration, Regression {
+    $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -SourceDirectories "Private" -Passthru
+    $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
+
+    It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
+        $Module | Should -Not -FileContentMatch '^Source$'
+    }
+
+    $Metadata = Import-Metadata $Output.Path
+
+    It "Should not have any FunctionsToExport if SourceDirectories don't match the PublicFilter" {
+        $Metadata.FunctionsToExport | Should -Be @()
+    }
+
+    It "Should de-dupe and move using statements to the top of the file" {
+        Select-String -Pattern "^using" -Path $Module | ForEach-Object LineNumber | Should -Be 1
+    }
+
+    It "Will comment out the original using statement in the original positions" {
+        (Select-String -Pattern "^#\s*using" -Path $Module).Count | Should -Be 2
+    }
+}
+
+Describe "Regression test for #55: I can pass SourceDirectories and PublicFilter" -Tag Integration, Regression {
+    $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -SourceDirectories "Private" -PublicFilter "P*\*" -Passthru
+    $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
+
+    It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
+        $Module | Should -Not -FileContentMatch '^Source$'
+    }
+
+    $Metadata = Import-Metadata $Output.Path
+
+    It "Should not have any FunctionsToExport if SourceDirectories don't match the PublicFilter" {
+        $Metadata.FunctionsToExport | Should -Be @("GetFinale", "GetPreview")
+    }
+
+    It "Should update AliasesToExport in the manifest" {
+        $Metadata.AliasesToExport | Should -Be @("GF", "GP")
+    }
+
+    It "Should de-dupe and move using statements to the top of the file" {
+        Select-String -Pattern "^using" -Path $Module | ForEach-Object LineNumber | Should -Be 1
+    }
+
+    It "Will comment out the original using statement in the original positions" {
+        (Select-String -Pattern "^#\s*using" -Path $Module).Count | Should -Be 2
+    }
+}
+
+Describe "Regression test for #84: Multiple Aliases per command will Export" -Tag Integration, Regression {
+    $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -Passthru
+
+    $Metadata = Import-Metadata $Output.Path
+
+    It "Should update AliasesToExport in the manifest" {
+        $Metadata.AliasesToExport | Should -Be @("GS","GSou", "SS", "SSou")
+    }
+}
+
+Describe "Supports building without a build.psd1" -Tag Integration {
+    Copy-Item  $PSScriptRoot\Source1 $PSScriptRoot\Copy1 -Recurse
+    Remove-Item $PSScriptRoot\Copy1\build.psd1
+    Rename-Item $PSScriptRoot\Copy1\Source1.psd1 Copy1.psd1
+
+    $Build = @{ }
+
+    It "No longer fails if there's no build.psd1" {
+        $BuildParameters = @{
+            SourcePath               = "$PSScriptRoot\Copy1\Copy1.psd1"
+            OutputDirectory          = "..\Result1"
+            VersionedOutputDirectory = $true
+        }
+
+        $Build.Output = Build-Module @BuildParameters -Passthru
+    }
+
+    Remove-Item -Recurse $PSScriptRoot\Copy1
+
+
+    It "Creates the same module as with a build.psd1" {
+        $Build.Metadata = Import-Metadata $Build.Output.Path
+    }
+
+    It "Should update AliasesToExport in the manifest" {
+        $Build.Metadata.AliasesToExport | Should -Be @("GS", "GSou", "SS", "SSou")
+    }
+
+    It "Should update FunctionsToExport in the manifest" {
+        $Build.Metadata.FunctionsToExport | Should -Be @("Get-Source", "Set-Source")
+    }
+}
+
+Describe "Regression test for #88 not copying prefix files" -Tag Integration, Regression {
+    $Output = Build-Module $PSScriptRoot\build.psd1 -Passthru
+
+    $Metadata = Import-Metadata $Output.Path
+
+    It "Should update AliasesToExport in the manifest" {
         $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
-
-        It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
-            $Module | Should -Not -FileContentMatch '^Source$'
-        }
-
-        $Metadata = Import-Metadata $Output.Path
-
-        It "Should update FunctionsToExport in the manifest" {
-            $Metadata.FunctionsToExport | Should -Be @("Get-Source", "Set-Source")
-        }
-
-        It "Should update AliasesToExport in the manifest" {
-            $Metadata.AliasesToExport -match "GS" | Should -Not -BeNullOrEmpty
-        }
-
-        It "Should de-dupe and move using statements to the top of the file" {
-            Select-String -Pattern "^using" -Path $Module | ForEach-Object LineNumber | Should -Be 1
-        }
-
-        It "Will comment out the original using statements in their original positions" {
-            (Select-String -Pattern "^#\s*using" -Path $Module).Count | Should -Be 3
-        }
-    }
-
-    Context "Regression test for #55: I can pass SourceDirectories" {
-        $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -SourceDirectories "Private" -Passthru
-        $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
-
-        It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
-            $Module | Should -Not -FileContentMatch '^Source$'
-        }
-
-        $Metadata = Import-Metadata $Output.Path
-
-        It "Should not have any FunctionsToExport if SourceDirectories don't match the PublicFilter" {
-            $Metadata.FunctionsToExport | Should -Be @()
-        }
-
-        It "Should de-dupe and move using statements to the top of the file" {
-            Select-String -Pattern "^using" -Path $Module | ForEach-Object LineNumber | Should -Be 1
-        }
-
-        It "Will comment out the original using statement in the original positions" {
-            (Select-String -Pattern "^#\s*using" -Path $Module).Count | Should -Be 2
-        }
-    }
-
-    Context "Regression test for #55: I can pass SourceDirectories and PublicFilter" {
-        $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -SourceDirectories "Private" -PublicFilter "P*\*" -Passthru
-        $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
-
-        It "Should not put the module's DefaultCommandPrefix into the psm1 as code. Duh!" {
-            $Module | Should -Not -FileContentMatch '^Source$'
-        }
-
-        $Metadata = Import-Metadata $Output.Path
-
-        It "Should not have any FunctionsToExport if SourceDirectories don't match the PublicFilter" {
-            $Metadata.FunctionsToExport | Should -Be @("GetFinale", "GetPreview")
-        }
-
-        It "Should update AliasesToExport in the manifest" {
-            $Metadata.AliasesToExport | Should -Be @("GF", "GP")
-        }
-
-        It "Should de-dupe and move using statements to the top of the file" {
-            Select-String -Pattern "^using" -Path $Module | ForEach-Object LineNumber | Should -Be 1
-        }
-
-        It "Will comment out the original using statement in the original positions" {
-            (Select-String -Pattern "^#\s*using" -Path $Module).Count | Should -Be 2
-        }
-    }
-
-    Context "Regression test for #84: Multiple Aliases per command will Export" {
-        $Output = Build-Module $PSScriptRoot\Source1\build.psd1 -Passthru
-
-        $Metadata = Import-Metadata $Output.Path
-
-        It "Should update AliasesToExport in the manifest" {
-            $Metadata.AliasesToExport | Should -Be @("GS","GSou", "SS", "SSou")
-        }
-    }
-
-    Context "Supports building without a build.psd1" {
-        Copy-Item  $PSScriptRoot\Source1 $PSScriptRoot\Copy1 -Recurse
-        Remove-Item $PSScriptRoot\Copy1\build.psd1
-        Rename-Item $PSScriptRoot\Copy1\Source1.psd1 Copy1.psd1
-
-        $Build = @{ }
-
-        It "No longer fails if there's no build.psd1" {
-            $BuildParameters = @{
-                SourcePath               = "$PSScriptRoot\Copy1\Copy1.psd1"
-                OutputDirectory          = "..\Result1"
-                VersionedOutputDirectory = $true
-            }
-
-            $Build.Output = Build-Module @BuildParameters -Passthru
-        }
-
-        Remove-Item -Recurse $PSScriptRoot\Copy1
-
-
-        It "Creates the same module as with a build.psd1" {
-            $Build.Metadata = Import-Metadata $Build.Output.Path
-        }
-
-        It "Should update AliasesToExport in the manifest" {
-            $Build.Metadata.AliasesToExport | Should -Be @("GS", "GSou", "SS", "SSou")
-        }
-
-        It "Should update FunctionsToExport in the manifest" {
-            $Build.Metadata.FunctionsToExport | Should -Be @("Get-Source", "Set-Source")
-        }
-
+        $ModuleInfo = Get-Content $Module
+        $ModuleInfo[0] | Should -be "using module Configuration"
     }
 }

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -88,24 +88,20 @@ Describe "Regression test for #84: Multiple Aliases per command will Export" -Ta
 }
 
 Describe "Supports building without a build.psd1" -Tag Integration {
-    Copy-Item  $PSScriptRoot\Source1 $PSScriptRoot\Copy1 -Recurse
-    Remove-Item $PSScriptRoot\Copy1\build.psd1
-    Rename-Item $PSScriptRoot\Copy1\Source1.psd1 Copy1.psd1
+    Copy-Item  $PSScriptRoot\Source1 TestDrive:\Source1 -Recurse
+    Remove-Item TestDrive:\Source1\build.psd1
 
     $Build = @{ }
 
     It "No longer fails if there's no build.psd1" {
         $BuildParameters = @{
-            SourcePath               = "$PSScriptRoot\Copy1\Copy1.psd1"
-            OutputDirectory          = "..\Result1"
+            SourcePath               = "TestDrive:\Source1\Source1.psd1"
+            OutputDirectory          = "TestDrive:\Result1"
             VersionedOutputDirectory = $true
         }
 
         $Build.Output = Build-Module @BuildParameters -Passthru
     }
-
-    Remove-Item -Recurse $PSScriptRoot\Copy1
-
 
     It "Creates the same module as with a build.psd1" {
         $Build.Metadata = Import-Metadata $Build.Output.Path

--- a/Tests/Integration/build.psd1
+++ b/Tests/Integration/build.psd1
@@ -2,4 +2,7 @@
     Path                     = "Source1\Source1.psd1"
     OutputDirectory          = "..\Result1"
     VersionedOutputDirectory = $true
+
+    # This file is not in Source1 it's here next to this build
+    Prefix                   = "..\using.ps1"
 }

--- a/Tests/Integration/using.ps1
+++ b/Tests/Integration/using.ps1
@@ -1,0 +1,1 @@
+using module Configuration

--- a/Tests/Private/ConvertToAst.Tests.ps1
+++ b/Tests/Private/ConvertToAst.Tests.ps1
@@ -1,5 +1,5 @@
+#requires -Module ModuleBuilder
 Describe "ConvertToAst" {
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     Context "It returns a ParseResult for file paths" {
         $ParseResult = InModuleScope ModuleBuilder {

--- a/Tests/Private/CopyReadMe.Tests.ps1
+++ b/Tests/Private/CopyReadMe.Tests.ps1
@@ -1,6 +1,6 @@
+#requires -Module ModuleBuilder
 Describe "Copy ReadMe" {
     . $PSScriptRoot\..\Convert-FolderSeparator.ps1
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     Context "There's no ReadMe" {
         # It should not even call Test-Path

--- a/Tests/Private/GetBuildInfo.Tests.ps1
+++ b/Tests/Private/GetBuildInfo.Tests.ps1
@@ -11,8 +11,9 @@ Describe "GetBuildInfo" {
 
     Context "It collects the initial data" {
 
-        New-Item "TestDrive:\MyModule\Source\build.psd1" -Type File -Force
-        New-Item "TestDrive:\MyModule\Source\MyModule.psd1" -Type File -Force
+        # use -Force to create the subdirectories
+        New-Item -Force "TestDrive:\MyModule\Source\build.psd1" -Type File -Value "@{ Path = 'MyModule.psd1' }"
+        New-ModuleManifest "TestDrive:\MyModule\Source\MyModule.psd1" -Author Tester
 
         $Result = InModuleScope -ModuleName ModuleBuilder {
 
@@ -68,18 +69,12 @@ Describe "GetBuildInfo" {
             }} | Should -Throw
         }
 
-        It 'Should throw if the Module manifest does not exists' {
+        It 'Should throw if the Module manifest does not exist' {
+            # use -Force to create the subdirectories
             New-Item -Force TestDrive:\NoModuleManifest\Source\build.psd1 -ItemType File
             {InModuleScope -ModuleName ModuleBuilder {
                     GetBuildInfo -BuildManifest TestDrive:\NoModuleManifest\Source\build.psd1
             }} | Should -Throw
         }
     }
-
-    Context "Invalid module manifest" {
-        # In the current PowerShell 5.1 and 6.1
-        # I can't make Get-Module -ListAvailable throw on a manifest
-        # So I can't test the if($Problems = ... code
-    }
-
 }

--- a/Tests/Private/GetBuildInfo.Tests.ps1
+++ b/Tests/Private/GetBuildInfo.Tests.ps1
@@ -47,7 +47,7 @@ Describe "GetBuildInfo" {
 
         It "Returns the resolved Module path, SourceDirectories, and overridden OutputDirectory (via Invocation param)" {
             # if set in build.psd1 it will stay the same (i.e. relative)
-            (Convert-FolderSeparator $Result.ModuleManifest) |
+            (Convert-FolderSeparator $Result.SourcePath) |
                 Should -Be (Convert-FolderSeparator "TestDrive:\MyModule\Source\MyModule.psd1")
 
             $Result.SourceDirectories | Should -Be @("Classes", "Public")
@@ -56,7 +56,7 @@ Describe "GetBuildInfo" {
     }
 
     Context 'Error when calling GetBuildInfo the wrong way' {
-        It 'Should throw if the ModuleManifestPath does not exist' {
+        It 'Should throw if the SourcePath does not exist' {
             {InModuleScope -ModuleName ModuleBuilder {
                 GetBuildInfo -BuildManifest TestDrive:\NOTEXIST\Source\build.psd1
             }} | Should -Throw

--- a/Tests/Private/GetBuildInfo.Tests.ps1
+++ b/Tests/Private/GetBuildInfo.Tests.ps1
@@ -1,6 +1,6 @@
+#requires -Module ModuleBuilder
 Describe "GetBuildInfo" {
     . $PSScriptRoot\..\Convert-FolderSeparator.ps1
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     Mock Import-Metadata -ModuleName ModuleBuilder {
         @{

--- a/Tests/Private/GetCommandAlias.Tests.ps1
+++ b/Tests/Private/GetCommandAlias.Tests.ps1
@@ -1,5 +1,5 @@
+#requires -Module ModuleBuilder
 Describe "GetCommandAlias" {
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     Context "Mandatory Parameter" {
         $CommandInfo = InModuleScope ModuleBuilder { Get-Command GetCommandAlias }

--- a/Tests/Private/ImportModuleManifest.Tests.ps1
+++ b/Tests/Private/ImportModuleManifest.Tests.ps1
@@ -1,0 +1,59 @@
+#requires -Module ModuleBuilder
+Describe "ImportModuleManifest" {
+
+    Context "Mandatory Parameter" {
+        $CommandInfo = InModuleScope ModuleBuilder { Get-Command ImportModuleManifest }
+
+        It 'has a mandatory Path parameter for the PSPath by pipeline' {
+            $Path = $CommandInfo.Parameters['Path']
+            $Path | Should -Not -BeNullOrEmpty
+            $Path.ParameterType | Should -Be ([string])
+            $Path.Aliases | Should -Be ("PSPath")
+            $Path.Attributes.Where{ $_ -is [Parameter] }.Mandatory | Should -Be $true
+            $Path.Attributes.Where{ $_ -is [Parameter] }.ValueFromPipelineByPropertyName | Should -Be $true
+        }
+
+    }
+
+    Context "Parsing Manifests" {
+        It "Does not cause errors for non-existent root modules" {
+            New-ModuleManifest -Path TestDrive:\BadRoot.psd1 -Author TestName -RootModule NoSuchFile
+
+            InModuleScope ModuleBuilder {
+                ImportModuleManifest -Path TestDrive:\BadRoot.psd1 -ErrorAction Stop
+            }
+        }
+
+        It "Returns the ModuleInfo with DefaultCommandPrefix instead of Prefix" {
+            New-ModuleManifest -Path TestDrive:\TestPrefix.psd1 -Author TestName -DefaultCommandPrefix PrePre
+
+            $Prefix = InModuleScope ModuleBuilder {
+                $DebugPreference = "Continue"
+                Get-ChildItem TestDrive:\TestPrefix.psd1 | ImportModuleManifest
+                $DebugPreference = "SilentlyContinue"
+            }
+
+            $Prefix.Prefix | Should -BeNullOrEmpty
+            $Prefix.DefaultCommandPrefix | Should -Be "PrePre"
+        }
+
+        It "Does cause errors for manifests that are invalid" {
+            New-ModuleManifest -Path TestDrive:\Invalid.psd1 -Author TestName -ModuleVersion "1.0.0"
+            Set-Content TestDrive:\Invalid.psd1 (
+                (Get-Content -Path TestDrive:\Invalid.psd1 -Raw) -replace "1.0.0"
+            )
+
+            {
+                InModuleScope ModuleBuilder {
+                    ImportModuleManifest -Path TestDrive:\Invalid.psd1 -ErrorAction Stop -WarningAction Stop
+                }
+            } | Should -Throw
+        }
+    }
+
+    Context "Invalid module manifest" {
+        # In the current PowerShell 5.1 and 6.1
+        # We can't make Get-Module -ListAvailable throw on a manifest
+        # So I can't test the if($Problems = ... code
+    }
+}

--- a/Tests/Private/InitializeBuild.Tests.ps1
+++ b/Tests/Private/InitializeBuild.Tests.ps1
@@ -1,6 +1,6 @@
+#requires -Module ModuleBuilder
 Describe "InitializeBuild" {
     . $PSScriptRoot\..\Convert-FolderSeparator.ps1
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     Context "It collects the initial data" {
 

--- a/Tests/Private/InitializeBuild.Tests.ps1
+++ b/Tests/Private/InitializeBuild.Tests.ps1
@@ -4,20 +4,15 @@ Describe "InitializeBuild" {
 
     Context "It collects the initial data" {
 
-        New-Item "TestDrive:\Source\build.psd1" -Type File -Force
-        New-Item "TestDrive:\Source\MyModule.psd1" -Type File -Force
-
-        Set-Content "TestDrive:\Source\MyModule.psd1" '@{
-            RootModule = "MyModule.psm1"
-            Author     = "Test Manager"
-            Version    = "1.0.0"
-        }'
-
         # Note that "Path" is an alias for "SourcePath"
-        Set-Content "TestDrive:\build.psd1" '@{
+        New-Item "TestDrive:\build.psd1" -Type File -Force -Value '@{
             Path = ".\Source\MyModule.psd1"
             SourceDirectories = @("Classes", "Private", "Public")
         }'
+
+        New-Item "TestDrive:\Source\" -Type Directory
+
+        New-ModuleManifest "TestDrive:\Source\MyModule.psd1" -RootModule "MyModule.psm1" -Author "Test Manager" -ModuleVersion "1.0.0"
 
         $Result = @{}
 
@@ -35,7 +30,7 @@ Describe "InitializeBuild" {
                     )
                     try {
                         Write-Warning $($MyInvocation.MyCommand | Out-String)
-                        InitializeBuild -SourcePath $SourcePath -Debug
+                        InitializeBuild -SourcePath $SourcePath
                     } catch {
                         $_
                     }
@@ -51,8 +46,8 @@ Describe "InitializeBuild" {
 
         It "Returns the ModuleInfo combined with the BuildInfo" {
             $Result.Name | Should -Be "MyModule"
-            $result.ModuleType | Should -Be "Manifest"
-            (Convert-FolderSeparator $Result.ModuleBase)      | Should -Be (Convert-FolderSeparator "TestDrive:\Source")
+            $Result.SourceDirectories | Should -Be @("Classes", "Private", "Public")
+            (Convert-FolderSeparator $Result.ModuleBase)  | Should -Be (Convert-FolderSeparator "TestDrive:\Source")
             (Convert-FolderSeparator $Result.SourcePath)  | Should -Be (Convert-FolderSeparator "TestDrive:\Source\MyModule.psd1")
         }
 

--- a/Tests/Private/MoveUsingStatements.Tests.ps1
+++ b/Tests/Private/MoveUsingStatements.Tests.ps1
@@ -1,5 +1,5 @@
+#requires -Module ModuleBuilder
 Describe "MoveUsingStatements" {
-
     Context "Necessary Parameters" {
         $CommandInfo = InModuleScope ModuleBuilder { Get-Command MoveUsingStatements }
 
@@ -96,7 +96,7 @@ Describe "MoveUsingStatements" {
         $MoveUsingStatementsCmd = InModuleScope ModuleBuilder {
             $null = Mock Write-Warning {}
             $null = Mock Set-Content {}
-            $null = Mock Write-Debug {} -ParameterFilter {$Message -eq "No Using Statement Error found." }
+            $null = Mock Write-Debug {} -ParameterFilter { $Message -eq "No using statement errors found." }
 
             {   param($RootModule)
                 ConvertToAst $RootModule | MoveUsingStatements
@@ -113,18 +113,17 @@ Describe "MoveUsingStatements" {
             Assert-MockCalled -CommandName Set-Content -Times 0 -ModuleName ModuleBuilder
         }
 
-        It 'Should not do anything when there are no Using Statements Errors' {
-
+        It 'Should not do anything when there are no using statement errors' {
             $testModuleFile = "$TestDrive\MyModule.psm1"
-            $PSM1File = "Using namespace System.IO; function x {}"
+            $PSM1File = "using namespace System.IO; function x {}"
             Set-Content $testModuleFile -value $PSM1File -Encoding UTF8
 
-            &$MoveUsingStatementsCmd -RootModule $testModuleFile
+            &$MoveUsingStatementsCmd -RootModule $testModuleFile -Debug
 
-            Assert-MockCalled -CommandName Write-Debug -Times 1 -ModuleName ModuleBuilder
-            Assert-MockCalled -CommandName Set-Content -Times 0 -ModuleName ModuleBuilder
             (Get-Content -Raw $testModuleFile).Trim() | Should -Be $PSM1File
 
+            Assert-MockCalled -CommandName Set-Content -Times 0 -ModuleName ModuleBuilder
+            Assert-MockCalled -CommandName Write-Debug -Times 1 -ModuleName ModuleBuilder
         }
 
 

--- a/Tests/Private/ParseLineNumber.Tests.ps1
+++ b/Tests/Private/ParseLineNumber.Tests.ps1
@@ -1,5 +1,5 @@
+#requires -Module ModuleBuilder
 Describe "ParseLineNumber" {
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     It 'Should get the SourceFile and LineNumber from stack trace messages with modules' {
         $Source = InModuleScope ModuleBuilder { ParseLineNumber "at Test-Throw<End>, C:\Test\Path\Modules\ErrorMaker\ErrorMaker.psm1: line 27" }

--- a/Tests/Private/ResolveBuildManifest.Tests.ps1
+++ b/Tests/Private/ResolveBuildManifest.Tests.ps1
@@ -1,5 +1,5 @@
+#requires -Module ModuleBuilder
 Describe "ResolveBuildManifest" {
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     [string]${Global:Test Root Path} = Resolve-Path $PSScriptRoot\..\..\Source
 

--- a/Tests/Private/ResolveBuildManifest.Tests.ps1
+++ b/Tests/Private/ResolveBuildManifest.Tests.ps1
@@ -25,16 +25,22 @@ Describe "ResolveBuildManifest" {
         $Expected | Should -Be (Join-Path ${Global:Test Root Path} "build.psd1")
     }
 
-    It "Should throw when passed a wrong absolute module manifest" {
-        {InModuleScope ModuleBuilder { ResolveBuildManifest (Join-Path (Join-Path ${Global:Test Root Path} ERROR) ModuleBuilder.psd1) }} | Should -Throw
+    It "Returns nothing when passed a wrong absolute module manifest" {
+        InModuleScope ModuleBuilder {
+            ResolveBuildManifest (Join-Path (Join-Path ${Global:Test Root Path} ERROR) ModuleBuilder.psd1) | Should -BeNullOrEmpty
+        }
     }
 
-    It "Should throw when passed the wrong folder path" {
-        {InModuleScope ModuleBuilder { ResolveBuildManifest (Join-Path ${Global:Test Root Path} "..") }} | Should -Throw
+    It "Returns nothing when passed the wrong folder path" {
+        InModuleScope ModuleBuilder {
+            ResolveBuildManifest (Join-Path ${Global:Test Root Path} "..") | Should -BeNullOrEmpty
+        }
     }
 
-    It "Should throw when passed the wrong folder relative path" {
-        {InModuleScope ModuleBuilder { ResolveBuildManifest (Join-Path . ..) }} | Should -Throw
+    It "Returns nothing when passed the wrong folder relative path" {
+        InModuleScope ModuleBuilder {
+            ResolveBuildManifest (Join-Path . ..) | Should -BeNullOrEmpty
+        }
     }
 
 }

--- a/Tests/Private/ResolveOutputFolder.Tests.ps1
+++ b/Tests/Private/ResolveOutputFolder.Tests.ps1
@@ -1,5 +1,5 @@
+#requires -Module ModuleBuilder
 Describe "ResolveOutputFolder" {
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     Context "Given an OutputDirectory and ModuleBase" {
 

--- a/Tests/Public/Build-Module.Tests.ps1
+++ b/Tests/Public/Build-Module.Tests.ps1
@@ -76,11 +76,11 @@ Describe "Build-Module" {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:\1.0.0"
-                Name = "MyModule"
-                ModuleBase = "TestDrive:\MyModule\"
+                Name            = "MyModule"
+                ModuleBase      = "TestDrive:\MyModule\"
                 CopyDirectories = @()
-                Encoding = "UTF8"
-                PublicFilter = "Public\*.ps1"
+                Encoding        = "UTF8"
+                PublicFilter    = "Public\*.ps1"
             }
         }
 
@@ -162,11 +162,11 @@ Describe "Build-Module" {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:\1.0.0"
-                Name = "MyModule"
-                ModuleBase = "TestDrive:\MyModule\"
+                Name            = "MyModule"
+                ModuleBase      = "TestDrive:\MyModule\"
                 CopyDirectories = @()
-                Encoding = "UTF8"
-                PublicFilter = "Public\*.ps1"
+                Encoding        = "UTF8"
+                PublicFilter    = "Public\*.ps1"
             }
         }
 
@@ -227,11 +227,11 @@ Describe "Build-Module" {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:\$Version"
-                Name = "MyModule"
-                ModuleBase = "TestDrive:\MyModule\"
+                Name            = "MyModule"
+                ModuleBase      = "TestDrive:\MyModule\"
                 CopyDirectories = @()
-                Encoding = "UTF8"
-                PublicFilter = "Public\*.ps1"
+                Encoding        = "UTF8"
+                PublicFilter    = "Public\*.ps1"
             }
         }
 
@@ -326,8 +326,8 @@ Describe "Build-Module" {
     Context "Setting the version and pre-release" {
         # $SemVer = "1.0.0-beta03+sha.22c35ffff166f34addc49a3b80e622b543199cc5.Date.2018-10-11"
         $SemVer = @{
-            Version = "1.0.0"
-            Prerelease = "beta03"
+            Version       = "1.0.0"
+            Prerelease    = "beta03"
             BuildMetadata = "Sha.22c35ffff166f34addc49a3b80e622b543199cc5.Date.2018-10-11"
         }
         $global:ExpectedVersion = "1.0.0"
@@ -342,11 +342,11 @@ Describe "Build-Module" {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:\$Version"
-                Name = "MyModule"
-                ModuleBase = "TestDrive:\MyModule\"
+                Name            = "MyModule"
+                ModuleBase      = "TestDrive:\MyModule\"
                 CopyDirectories = @()
-                Encoding = "UTF8"
-                PublicFilter = "Public\*.ps1"
+                Encoding        = "UTF8"
+                PublicFilter    = "Public\*.ps1"
             }
         }
 
@@ -536,7 +536,7 @@ Describe "Build-Module" {
 
         Mock GetBuildInfo -ModuleName ModuleBuilder {
             [PSCustomObject]@{
-                ModuleManifest    = "TestDrive:\MyModule.psd1"
+                SourcePath        = "TestDrive:\MyModule.psd1"
                 Version           = [Version]"1.0.0"
                 OutputDirectory   = "./output"
                 Encoding          = 'UTF8'

--- a/Tests/Public/Build-Module.Tests.ps1
+++ b/Tests/Public/Build-Module.Tests.ps1
@@ -531,7 +531,7 @@ Describe "Build-Module" {
     Context "Does not fall over if you build from the drive root" {
 
         $null = New-Item "TestDrive:\build.psd1" -Type File -Force -Value "@{}"
-        $null = New-Item "TestDrive:\MyModule.psd1" -Type File -Force -value '@{ModuleVersion="1.0.0";Author="TEST"}'
+        $null = New-ModuleManifest "TestDrive:\MyModule.psd1" -ModuleVersion "1.0.0" -Author "Tester"
         $null = New-Item "TestDrive:\Public\Test.ps1" -Type File -Value 'MATCHING TEST CONTENT' -Force
 
         Mock GetBuildInfo -ModuleName ModuleBuilder {

--- a/Tests/Public/Convert-LineNumber.Tests.ps1
+++ b/Tests/Public/Convert-LineNumber.Tests.ps1
@@ -1,5 +1,5 @@
+#requires -Module ModuleBuilder
 Describe "Convert-LineNumber" {
-    Import-Module ModuleBuilder -DisableNameChecking -Verbose:$False
 
     $ModulePath = Join-Path (Get-Module ModuleBuilder).ModuleBase ModuleBuilder.psm1
     $ModuleContent = Get-Content $ModulePath

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     endpoint: PoshCode
     type: github
     name: PoshCode/Azure-Pipelines
-    ref: refs/tags/3.2.1
+    ref: refs/tags/3.2.2
 
 stages:
 - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     endpoint: PoshCode
     type: github
     name: PoshCode/Azure-Pipelines
-    ref: refs/tags/3.2.0
+    ref: refs/tags/3.2.1
 
 stages:
 - stage: Build

--- a/build.ps1
+++ b/build.ps1
@@ -12,9 +12,10 @@ param(
     [Alias("ModuleVersion")]
     [string]$SemVer
 )
-
 # Sanitize parameters to pass to Build-Module
 $null = $PSBoundParameters.Remove('Test')
+$ErrorActionPreference = "Stop"
+Push-Location $PSScriptRoot -StackName BuildBuildModule
 
 if (-not $Semver) {
     if ($semver = gitversion -showvariable SemVer) {
@@ -22,9 +23,6 @@ if (-not $Semver) {
     }
 }
 
-
-$ErrorActionPreference = "Stop"
-Push-Location $PSScriptRoot -StackName BuildBuildModule
 try {
     # Build ModuleBuilder with ModuleBuilder:
     Write-Verbose "Compiling ModuleBuilderBootstrap module"

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,44 @@
+#requires -Module PowerShellGet, Pester
+using namespace Microsoft.PackageManagement.Provider.Utility
+param(
+    [switch]$SkipCodeCoverage,
+    [switch]$HideSuccess
+    [switch]$IncludeVSCodeMarker
+)
+Push-Location $PSScriptRoot
+$ModuleUnderTest = Split-Path $PSScriptRoot -Leaf
+
+# Disable default parameters during testing, just in case
+$PSDefaultParameterValues += @{}
+$PSDefaultParameterValues["Disabled"] = $true
+
+# Find a built module as a version-numbered folder:
+$FullModulePath = Get-ChildItem [0-9]* -Directory | Sort-Object { $_.Name -as [SemanticVersion[]] } |
+    Select-Object -Last 1 -Ov Version |
+    Get-ChildItem -Filter "$($ModuleUnderTest).psd1"
+
+    if(!$FullModulePath) {
+        throw "Can't find $($ModuleUnderTest).psd1 in $($Version.FullName)"
+    }
+
+$Show = if ($HideSuccess) {
+    "Fails"
+} else {
+    "All"
+}
+
+Remove-Module (Split-Path $ModuleUnderTest -Leaf) -ErrorAction Ignore -Force
+$ModuleUnderTest = Import-Module $FullModulePath -PassThru -Force -DisableNameChecking -Verbose:$false
+Write-Host "Invoke-Pester for Module $($ModuleUnderTest) version $($ModuleUnderTest.Version)"
+
+if (-not $SkipCodeCoverage) {
+    # Get code coverage for the psm1 file to a coverage.xml that we can mess with later
+    Invoke-Pester (Join-Path $PSScriptRoot Tests) -CodeCoverage $ModuleUnderTest.Path -CodeCoverageOutputFile ./coverage.xml -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
+} else {
+    Invoke-Pester (Join-Path $PSScriptRoot Tests) -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
+}
+
+Pop-Location
+
+# Re-enable default parameters after testing
+$PSDefaultParameterValues["Disabled"] = $false

--- a/test.ps1
+++ b/test.ps1
@@ -2,11 +2,11 @@
 using namespace Microsoft.PackageManagement.Provider.Utility
 param(
     [switch]$SkipCodeCoverage,
-    [switch]$HideSuccess
+    [switch]$HideSuccess,
     [switch]$IncludeVSCodeMarker
 )
 Push-Location $PSScriptRoot
-$ModuleUnderTest = Split-Path $PSScriptRoot -Leaf
+$ModuleName = "ModuleBuilder"
 
 # Disable default parameters during testing, just in case
 $PSDefaultParameterValues += @{}
@@ -15,10 +15,10 @@ $PSDefaultParameterValues["Disabled"] = $true
 # Find a built module as a version-numbered folder:
 $FullModulePath = Get-ChildItem [0-9]* -Directory | Sort-Object { $_.Name -as [SemanticVersion[]] } |
     Select-Object -Last 1 -Ov Version |
-    Get-ChildItem -Filter "$($ModuleUnderTest).psd1"
+    Get-ChildItem -Filter "$($ModuleName).psd1"
 
-    if(!$FullModulePath) {
-        throw "Can't find $($ModuleUnderTest).psd1 in $($Version.FullName)"
+    if (!$FullModulePath) {
+        throw "Can't find $($ModuleName).psd1 in $($Version.FullName)"
     }
 
 $Show = if ($HideSuccess) {
@@ -27,15 +27,15 @@ $Show = if ($HideSuccess) {
     "All"
 }
 
-Remove-Module (Split-Path $ModuleUnderTest -Leaf) -ErrorAction Ignore -Force
+Remove-Module (Split-Path $ModuleName -Leaf) -ErrorAction Ignore -Force
 $ModuleUnderTest = Import-Module $FullModulePath -PassThru -Force -DisableNameChecking -Verbose:$false
 Write-Host "Invoke-Pester for Module $($ModuleUnderTest) version $($ModuleUnderTest.Version)"
 
 if (-not $SkipCodeCoverage) {
     # Get code coverage for the psm1 file to a coverage.xml that we can mess with later
-    Invoke-Pester (Join-Path $PSScriptRoot Tests) -CodeCoverage $ModuleUnderTest.Path -CodeCoverageOutputFile ./coverage.xml -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
+    Invoke-Pester ./Tests -CodeCoverage $ModuleUnderTest.Path -CodeCoverageOutputFile ./coverage.xml -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
 } else {
-    Invoke-Pester (Join-Path $PSScriptRoot Tests) -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
+    Invoke-Pester ./Tests -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
 }
 
 Pop-Location


### PR DESCRIPTION
Fixes #87 by not using ModuleManifest explicitly anymore
Fixes #88 by not loosing the value of the prefix
Address #44 because #87 was so darn close. The build.psd1 is optional

I don't _think_ this will break anything, but I'd like some reassurance.
If there's any doubt, I'll do a 2.0.0-alpha01 and we can beg people to test it.

Regardless, even if nobody finds any bugs, I'm willing to bump major because of the build.psd1 change if y'all think it's necessary