### PR TITLE
Change CopyDirectories to CopyPaths and 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 obj/
 Output/
 Tools/
+coverage.xml

--- a/Source/Private/GetBuildInfo.ps1
+++ b/Source/Private/GetBuildInfo.ps1
@@ -11,15 +11,10 @@ function GetBuildInfo {
         $BuildCommandInvocation
     )
 
-    $BuildInfo = if ($BuildManifest -and (Test-Path $BuildManifest)) {
-        if ((Split-path -Leaf $BuildManifest) -eq 'build.psd1') {
-            # Read the Module Manifest configuration file for default parameter values
-            Write-Debug "Load Build Manifest $BuildManifest"
-            Import-Metadata -Path $BuildManifest
-        } else {
-            Write-Debug "Use SourcePath $BuildManifest"
-            @{ SourcePath = $BuildManifest }
-        }
+    $BuildInfo = if ($BuildManifest -and (Test-Path $BuildManifest) -and (Split-path -Leaf $BuildManifest) -eq 'build.psd1') {
+        # Read the build.psd1 configuration file for default parameter values
+        Write-Debug "Load Build Manifest $BuildManifest"
+        Import-Metadata -Path $BuildManifest
     } else {
         @{}
     }

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -276,5 +276,6 @@ function Build-Module {
         } finally {
             Pop-Location -StackName Build-Module -ErrorAction SilentlyContinue
         }
+        Write-Progress "Building $($ModuleInfo.Name)" -Completed
     }
 }

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -17,7 +17,7 @@ function Build-Module {
             The optimization process:
             1. The OutputDirectory is created
             2. All psd1/psm1/ps1xml files (except build.psd1) in the Source will be copied to the output
-            3. If specified, $CopyDirectories (relative to the Source) will be copied to the output
+            3. If specified, $CopyPaths (relative to the Source) will be copied to the output
             4. The ModuleName.psm1 will be generated (overwritten completely) by concatenating all .ps1 files in the $SourceDirectories subdirectories
             5. The ModuleVersion and ExportedFunctions in the ModuleName.psd1 may be updated (depending on parameters)
 
@@ -88,7 +88,8 @@ function Build-Module {
         # Folders which should be copied intact to the module output
         # Can be relative to the  module folder
         [AllowEmptyCollection()]
-        [string[]]$CopyDirectories = @(),
+        [Alias("CopyDirectories")]
+        [string[]]$CopyPaths = @(),
 
         # Folders which contain source .ps1 scripts to be concatenated into the module
         # Defaults to Enum, Classes, Private, Public
@@ -194,9 +195,9 @@ function Build-Module {
             Write-Verbose "Copy files to $OutputDirectory"
             # Copy the files and folders which won't be processed
             Copy-Item *.psm1, *.psd1, *.ps1xml -Exclude "build.psd1" -Destination $OutputDirectory -Force
-            if ($ModuleInfo.CopyDirectories) {
-                Write-Verbose "Copy Entire Directories: $($ModuleInfo.CopyDirectories)"
-                Copy-Item -Path $ModuleInfo.CopyDirectories -Recurse -Destination $OutputDirectory -Force
+            if ($ModuleInfo.CopyPaths) {
+                Write-Verbose "Copy Entire Directories: $($ModuleInfo.CopyPaths)"
+                Copy-Item -Path $ModuleInfo.CopyPaths -Recurse -Destination $OutputDirectory -Force
             }
 
             Write-Verbose "Combine scripts to $RootModule"

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -1,7 +1,3 @@
-if (!(Get-Verb Build) -and $MyInvocation.Line -notmatch "DisableNameChecking") {
-    Write-Warning "The verb 'Build' was approved recently, but PowerShell $($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) doesn't know. You will be warned about Build-Module."
-}
-
 function Build-Module {
     <#
         .Synopsis

--- a/Source/Public/Convert-LineNumber.ps1
+++ b/Source/Public/Convert-LineNumber.ps1
@@ -39,11 +39,10 @@ function Convert-LineNumber {
             $SourceFile = $Invocation.SourceFile
             $SourceLineNumber = $Invocation.SourceLineNumber
         }
-        $PSScriptRoot = Split-Path $SourceFile
-
         if(!(Test-Path $SourceFile)) {
             throw "'$SourceFile' does not exist"
         }
+        $PSScriptRoot = Split-Path $SourceFile
 
         Push-Location $PSScriptRoot
         try {

--- a/Tests/Public/Build-Module.Tests.ps1
+++ b/Tests/Public/Build-Module.Tests.ps1
@@ -9,6 +9,9 @@ Describe "Build-Module" {
             $parameters["SourcePath"].ParameterType | Should -Be ([string])
             $parameters["SourcePath"].Attributes.Where{$_ -is [Parameter]}.Mandatory | Should -Be $false
         }
+        It "throws if the SourcePath doesn't exist" {
+            { Build-Module -SourcePath TestDrive:\NoSuchPath } | Should -Throw "Source must point to a valid module"
+        }
 
         It "has an optional string parameter for the OutputDirectory" {
             $parameters.ContainsKey("OutputDirectory") | Should -Be $true
@@ -16,20 +19,27 @@ Describe "Build-Module" {
             $parameters["OutputDirectory"].Attributes.Where{$_ -is [Parameter]}.Mandatory | Should -Be $false
         }
 
-        It "has an optional parameter for setting the Version"{
+        It "has an optional parameter for setting the Version" {
             $parameters.ContainsKey("Version") | Should -Be $true
             $parameters["Version"].ParameterType | Should -Be ([version])
             $parameters["Version"].ParameterSets.Keys | Should -Not -Be "__AllParameterSets"
         }
 
-        It "has an optional parameter for setting the Encoding"{
+        It "has an optional parameter for setting the Encoding" {
             $parameters.ContainsKey("Encoding") | Should -Be $true
             # Note that in PS Core, we can't use encoding types for parameters
             $parameters["Encoding"].ParameterType | Should -Be ([string])
             $parameters["Encoding"].Attributes.Where{$_ -is [Parameter]}.Mandatory | Should -Be $false
         }
 
-        It "has an optional string parameter for a Prefix"{
+        It "Warns if you set the encoding to anything but UTF8" {
+            $warns = @()
+            # Note: Using WarningAction Stop just to avoid testing anything else here ;)
+            try { Build-Module -Encoding ASCII -WarningAction Stop -WarningVariable +warns } catch {}
+            $warns.Message | Should -Match "recommend you build your script modules with UTF8 encoding"
+        }
+
+        It "has an optional string parameter for a Prefix" {
             $parameters.ContainsKey("Prefix") | Should -Be $true
             $parameters["Prefix"].ParameterType | Should -Be ([string])
             $parameters["Prefix"].Attributes.Where{$_ -is [Parameter]}.Mandatory | Should -Be $false

--- a/Tests/Public/Convert-LineNumber.Tests.ps1
+++ b/Tests/Public/Convert-LineNumber.Tests.ps1
@@ -26,6 +26,10 @@ Describe "Convert-LineNumber" {
         }
     }
 
+    It "Should throw if the SourceFile doesn't exist" {
+        { Convert-LineNumber -SourceFile TestDrive:\NoSuchFile -SourceLineNumber 10 } | Should Throw "'TestDrive:\NoSuchFile' does not exist"
+    }
+
     It 'Should work with an error PositionMessage' {
         $line = Select-String -Path $ModulePath 'function ParseLineNumber {' | % LineNumber
 

--- a/build.ps1
+++ b/build.ps1
@@ -13,7 +13,6 @@ param(
     [string]$SemVer
 )
 # Sanitize parameters to pass to Build-Module
-$null = $PSBoundParameters.Remove('Test')
 $ErrorActionPreference = "Stop"
 Push-Location $PSScriptRoot -StackName BuildBuildModule
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <!-- install packages to a custom path -->
   <config>
-    <add key="globalPackagesFolder" value="Tools"/>
+    <add key="globalPackagesFolder" value="Tools" />
   </config>
   <packageSources>
     <clear />
-    <add key="powershell" value="https://www.Preview.PowerShellGallery.Com/api/v2" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test.ps1
+++ b/test.ps1
@@ -33,7 +33,10 @@ Write-Host "Invoke-Pester for Module $($ModuleUnderTest) version $($ModuleUnderT
 
 if (-not $SkipCodeCoverage) {
     # Get code coverage for the psm1 file to a coverage.xml that we can mess with later
-    Invoke-Pester ./Tests -CodeCoverage $ModuleUnderTest.Path -CodeCoverageOutputFile ./coverage.xml -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
+    Invoke-Pester ./Tests -Show $Show -PesterOption @{
+        IncludeVSCodeMarker = $IncludeVSCodeMarker
+    } -CodeCoverage $ModuleUnderTest.Path -CodeCoverageOutputFile ./coverage.xml -PassThru |
+        Convert-CodeCoverage -SourceRoot ./Source -Relative
 } else {
     Invoke-Pester ./Tests -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
 }


### PR DESCRIPTION
We'll keep an alias for the old name, but this parameter works for single files or wildcard paths too.

While I'm making tiny edits, a few others:
1. Stop warning about how PS5 will warn about Build. If people don't know PS6 and PS7 have additional verbs, there's no point continuing to educate now.
2. Complete the progress display after the build finishes. Using Build-Module in scripts that build _and also_ test, etc., we don't want the progress to stay visible the whole time.
3. Remove some unused code

+semver:fix