### PR TITLE
Import source module manifest without failing

### DIFF
--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -140,7 +140,7 @@ Describe "Supports building without a build.psd1 that has parent folder with a n
 
     It "No longer fails if there's no build.psd1" {
         $BuildParameters = @{
-            SourcePath               = "TestDrive:\s\Source1.psd1"
+            SourcePath               = "TestDrive:\s"
             OutputDirectory          = "TestDrive:\Result1"
             VersionedOutputDirectory = $true
         }


### PR DESCRIPTION
This fixes an issue that still exist when there is no build module manifest and the `SourcePath` is a folder that does not contain the module name. 

Prior to this fix the build was successful if SourcePath was either `c:\source\ModuleName` or `c:\source\ModuleName\source\ModuleName.psd1`, but failed if SourcePath was `c:\source\s` (and the module manifest was in `c:\source\s\source\ModuleName.psd1`. This is solved with this PR.

- Fixes #94

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/poshcode/modulebuilder/95)
<!-- Reviewable:end -->
