### PR TITLE
BREAKING CHANGE: addresses #65 and changes output path calculation

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
             },
             "presentation": {
                 "echo": true,
-                "reveal": "silent",
+                "reveal": "always",
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": true,

--- a/Install-RequiredModule.ps1
+++ b/Install-RequiredModule.ps1
@@ -1,0 +1,7 @@
+Push-Location $PSScriptRoot
+try {
+    Install-Script Install-RequiredModule
+    Install-RequiredModule
+} finally {
+    Pop-Location
+}

--- a/PotentialContribution/ModuleCreation.ps1
+++ b/PotentialContribution/ModuleCreation.ps1
@@ -8,11 +8,9 @@ $helpPath = Join-Path $modulePath en-US
 
 $HelpFile = Join-Path $helpPath "$moduleName.psm1-help.xml"
 
-mkdir $helpPath -Force #create both module folder and help folder
+New-Item -ItemType Directory $helpPath -Force #create both module folder and help folder
 
 New-ModuleManifest $modulePath -RootModule "$moduleName.psm1" -ModuleVersion 0.0.0.1
-
-
 
 New-Item -Path $modulePath -Name "${moduleName}_${guid}_HelpInfo.xml" -ItemType File -Value "" ## templated, get guid from psd1
 New-Item -Path $helpPath -Name "$moduleName.psm1-help.xml" -ItemType File -Value "" #pull value from template some place

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -40,8 +40,16 @@ We have a few modules which are required for building. They're listed in `Requir
 
 #### 3. Run the `build.ps1` script.
 
+By default, the build script uses [gitversion](/gittols/gitversion) to calculate the version of the build automatically:
+
 ```powershell
 .\build.ps1
+```
+
+If you don't have gitversion handy, you can just specify a version for the `-Semver` parameter:
+
+```powershell
+.\build.ps1 -Semver 2.0.0-beta
 ```
 
 #### 4. Make the compiled module available to Powershell

--- a/Source/Private/GetRelativePath.ps1
+++ b/Source/Private/GetRelativePath.ps1
@@ -1,0 +1,54 @@
+function GetRelativePath {
+    <#
+        .SYNOPSIS
+            Returns the relative path, or $Path if the paths don't share the same root.
+            For backward compatibility, this is [System.IO.Path]::GetRelativePath for .NET 4.x
+    #>
+    [CmdletBinding()]
+    param(
+        # The source path the result should be relative to. This path is always considered to be a directory.
+        [Parameter(Mandatory)]
+        [string]$RelativeTo,
+
+        # The destination path.
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    # This giant mess is because PowerShell drives aren't valid filesystem drives
+    $Drive = $Path -replace "^([^\\/]+:[\\/])?.*", '$1'
+    if ($Drive -ne ($RelativeTo -replace "^([^\\/]+:[\\/])?.*", '$1')) {
+        Write-Verbose "Paths on different drives"
+        return $Path # no commonality, different drive letters on windows
+    }
+    $RelativeTo = $RelativeTo -replace "^[^\\/]+:[\\/]", [IO.Path]::DirectorySeparatorChar
+    $Path = $Path -replace "^[^\\/]+:[\\/]", [IO.Path]::DirectorySeparatorChar
+    $RelativeTo = [IO.Path]::GetFullPath($RelativeTo).TrimEnd('\/') -replace "^[^\\/]+:[\\/]", [IO.Path]::DirectorySeparatorChar
+    $Path = [IO.Path]::GetFullPath($Path) -replace "^[^\\/]+:[\\/]", [IO.Path]::DirectorySeparatorChar
+
+    $commonLength = 0
+    while ($Path[$commonLength] -eq $RelativeTo[$commonLength]) {
+        $commonLength++
+    }
+    if ($commonLength -eq $RelativeTo.Length -and $RelativeTo.Length -eq $Path.Length) {
+        Write-Verbose "Equal Paths"
+        return "." # The same paths
+    }
+    if ($commonLength -eq 0) {
+        Write-Verbose "Paths on different drives?"
+        return $Drive + $Path # no commonality, different drive letters on windows
+    }
+
+    Write-Verbose "Common base: $commonLength $($RelativeTo.Substring(0,$commonLength))"
+    # In case we matched PART of a name, like C:\Users\Joel and C:\Users\Joe
+    while ($commonLength -gt $RelativeTo.Length -and ($RelativeTo[$commonLength] -ne [IO.Path]::DirectorySeparatorChar)) {
+        $commonLength--
+    }
+
+    Write-Verbose "Common base: $commonLength $($RelativeTo.Substring(0,$commonLength))"
+    # create '..' segments for segments past the common on the "$RelativeTo" path
+    if ($commonLength -lt $RelativeTo.Length) {
+        $result = @('..') * @($RelativeTo.Substring($commonLength).Split([IO.Path]::DirectorySeparatorChar).Where{ $_ }).Length -join ([IO.Path]::DirectorySeparatorChar)
+    }
+    (@($result, $Path.Substring($commonLength).TrimStart([IO.Path]::DirectorySeparatorChar)).Where{ $_ } -join ([IO.Path]::DirectorySeparatorChar))
+}

--- a/Source/Private/GetRelativePath.ps1
+++ b/Source/Private/GetRelativePath.ps1
@@ -4,6 +4,7 @@ function GetRelativePath {
             Returns the relative path, or $Path if the paths don't share the same root.
             For backward compatibility, this is [System.IO.Path]::GetRelativePath for .NET 4.x
     #>
+    [OutputType([string])]
     [CmdletBinding()]
     param(
         # The source path the result should be relative to. This path is always considered to be a directory.

--- a/Source/Private/InitializeBuild.ps1
+++ b/Source/Private/InitializeBuild.ps1
@@ -33,6 +33,11 @@ function InitializeBuild {
         ) -join ' ')"
     $BuildInfo = GetBuildInfo -BuildManifest $BuildManifest -BuildCommandInvocation $BuildCommandInvocation
 
+    # Override VersionedOutputDirectory with UnversionedOutputDirectory
+    if ($BuildInfo.UnversionedOutputDirectory -and $BuildInfo.VersionedOutputDirectory) {
+        $BuildInfo.VersionedOutputDirectory = $false
+    }
+
     # Finally, add all the information in the module manifest to the return object
     if ($ModuleInfo = ImportModuleManifest $BuildInfo.SourcePath) {
         # Update the module manifest with our build configuration and output it

--- a/Source/Private/ResolveOutputFolder.ps1
+++ b/Source/Private/ResolveOutputFolder.ps1
@@ -1,23 +1,35 @@
 function ResolveOutputFolder {
     [CmdletBinding()]
     param(
+        # The name of the module to build
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias("Name")]
+        [string]$ModuleName,
+
+        # Where to resolve the $OutputDirectory from when relative
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias("ModuleBase")]
+        [string]$Source,
+
         # Where to build the module.
         # Defaults to an \output folder, adjacent to the "SourcePath" folder
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [string]$OutputDirectory,
 
-        # If set (true) adds a folder named after the version number to the OutputDirectory
-        [Parameter(ValueFromPipelineByPropertyName)]
-        [switch]$VersionedOutputDirectory,
-
         # specifies the module version for use in the output path if -VersionedOutputDirectory is true
-        [Parameter(ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias("ModuleVersion")]
         [string]$Version,
 
-        # Where to resolve the $OutputDirectory from when relative
+        # If set (true) adds a folder named after the version number to the OutputDirectory
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [Alias("Force")]
+        [switch]$VersionedOutputDirectory,
+
+        # Controls whether or not there is a build or cleanup performed
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-        [string]$ModuleBase
+        [ValidateSet("Clean", "Build", "CleanBuild")]
+        [string]$Target = "CleanBuild"
     )
     process {
         Write-Verbose "Resolve OutputDirectory path: $OutputDirectory"
@@ -25,15 +37,43 @@ function ResolveOutputFolder {
         # Ensure the OutputDirectory makes sense (it's never blank anymore)
         if (!(Split-Path -IsAbsolute $OutputDirectory)) {
             # Relative paths are relative to the ModuleBase
-            $OutputDirectory = Join-Path $ModuleBase $OutputDirectory
+            $OutputDirectory = Join-Path $Source $OutputDirectory
+        }
+        # If they passed in a path with ModuleName\Version on the end...
+        if ((Split-Path $OutputDirectory -Leaf).EndsWith($Version) -and (Split-Path (Split-Path $OutputDirectory) -Leaf) -eq $ModuleName) {
+            # strip the version (so we can add it back)
+            $VersionedOutputDirectory = $true
+            $OutputDirectory = Split-Path $OutputDirectory
+        }
+        # Ensure the OutputDirectory is named "ModuleName"
+        if ((Split-Path $OutputDirectory -Leaf) -ne $ModuleName) {
+            # If it wasn't, add a "ModuleName"
+            $OutputDirectory = Join-Path $OutputDirectory $ModuleName
+        }
+        # Ensure the OutputDirectory is not a parent of the SourceDirectory
+        if (-not [io.path]::GetRelativePath($OutputDirectory, $Source).StartsWith("..")) {
+            Write-Verbose "Added Version to OutputDirectory path: $OutputDirectory"
+            $OutputDirectory = Join-Path $OutputDirectory $Version
+        }
+        # Ensure the version number is on the OutputDirectory if it's supposed to be
+        if ($VersionedOutputDirectory -and -not (Split-Path $OutputDirectory -Leaf).EndsWith($Version)) {
+            Write-Verbose "Added Version to OutputDirectory path: $OutputDirectory"
+            $OutputDirectory = Join-Path $OutputDirectory $Version
         }
 
-        # Make sure the OutputDirectory exists (relative to ModuleBase or absolute)
-        $OutputDirectory = New-Item $OutputDirectory -ItemType Directory -Force | Convert-Path
-        if ($VersionedOutputDirectory -and $OutputDirectory.TrimEnd("/\") -notmatch "\d+\.\d+\.\d+$") {
-            $OutputDirectory = New-Item (Join-Path $OutputDirectory $Version) -ItemType Directory -Force | Convert-Path
-            Write-Verbose "Added ModuleVersion to OutputDirectory path: $OutputDirectory"
+        if (Test-Path $OutputDirectory -PathType Leaf) {
+            throw "Unable to build. There is a file in the way at $OutputDirectory"
         }
-        $OutputDirectory
+
+        if ($Target -match "Clean") {
+            Write-Verbose "Cleaning $OutputDirectory"
+            if (Test-Path $OutputDirectory -PathType Container) {
+                Remove-Item $OutputDirectory -Recurse -Force
+            }
+        }
+        if ($Target -match "Build") {
+            # Make sure the OutputDirectory exists (relative to ModuleBase or absolute)
+            New-Item $OutputDirectory -ItemType Directory -Force | Convert-Path
+        }
     }
 }

--- a/Source/Private/ResolveOutputFolder.ps1
+++ b/Source/Private/ResolveOutputFolder.ps1
@@ -51,7 +51,7 @@ function ResolveOutputFolder {
             $OutputDirectory = Join-Path $OutputDirectory $ModuleName
         }
         # Ensure the OutputDirectory is not a parent of the SourceDirectory
-        if (-not [io.path]::GetRelativePath($OutputDirectory, $Source).StartsWith("..")) {
+        if (-not (GetRelativePath $OutputDirectory $Source).StartsWith("..")) {
             Write-Verbose "Added Version to OutputDirectory path: $OutputDirectory"
             $OutputDirectory = Join-Path $OutputDirectory $Version
         }

--- a/Source/Private/ResolveOutputFolder.ps1
+++ b/Source/Private/ResolveOutputFolder.ps1
@@ -51,7 +51,8 @@ function ResolveOutputFolder {
             $OutputDirectory = Join-Path $OutputDirectory $ModuleName
         }
         # Ensure the OutputDirectory is not a parent of the SourceDirectory
-        if (-not (GetRelativePath $OutputDirectory $Source).StartsWith("..")) {
+        $RelativeOutputPath = GetRelativePath $OutputDirectory $Source
+        if (-not $RelativeOutputPath.StartsWith("..") -and $RelativeOutputPath -ne $Source) {
             Write-Verbose "Added Version to OutputDirectory path: $OutputDirectory"
             $OutputDirectory = Join-Path $OutputDirectory $Version
         }

--- a/Source/Private/SetModuleContent.ps1
+++ b/Source/Private/SetModuleContent.ps1
@@ -48,7 +48,7 @@ function SetModuleContent {
                 Write-Verbose "Adding $SourceName"
                 $SetContent.Process("#Region '$SourceName' 0")
                 Get-Content $SourceName -OutVariable source | ForEach-Object { $SetContent.Process($_) }
-                $SetContent.Process("#EndRegion '$SourceName' $($Source.Count)")
+                $SetContent.Process("#EndRegion '$SourceName' $($Source.Count+1)")
             } else {
                 if(!$ContentStarted) {
                     $SetContent.Process("#Region 'PREFIX' 0")

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -38,6 +38,7 @@ function Build-Module {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification="Build is approved now")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCmdletCorrectly", "")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="Parameter handling is in InitializeBuild")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidDefaultValueSwitchParameter", "", Justification = "VersionedOutputDirectory is Deprecated")]
     [CmdletBinding(DefaultParameterSetName="SemanticVersion")]
     [Alias("build")]
     param(
@@ -54,16 +55,16 @@ function Build-Module {
         [string]$SourcePath = $(Get-Location -PSProvider FileSystem),
 
         # Where to build the module. Defaults to "..\Output" adjacent to the "SourcePath" folder.
-        # The actual OutputDirectory may be a subfolder of this, because the path always ends with \ModuleName or \ModuleName\Version
-        # -OutputDirectory ..\Output,  the actual path is ..\Output\ModuleName or ..\Output\ModuleName\1.2.3
-        # -OutputDirectory ..\,        the actual path is ..\Output\ModuleName or ..\Output\ModuleName\1.2.3
-        # -OutputDirectory ..\b\10.2,  the actual path is ..\b\10.2\ModuleName\1.2.3
-        # -OutputDirectory ..\b\ModuleName\1.2.3, the actual path is ..\b\ModuleName\1.2.3
+        # The ACTUAL output may be in a subfolder of this path ending with the module name and version
+        # The default value is ..\Output which results in the build going to ..\Output\ModuleName\1.2.3
         [Alias("Destination")]
         [string]$OutputDirectory = "..\Output",
 
-        # If set (true) adds a folder named after the version number to the OutputDirectory
-        [switch]$VersionedOutputDirectory,
+        # DEPRECATED. Now defaults true, producing a OutputDirectory with a version number as the last folder
+        [switch]$VersionedOutputDirectory = $true,
+
+        # Overrides the VersionedOutputDirectory, producing an OutputDirectory without a version number as the last folder
+        [switch]$UnversionedOutputDirectory,
 
         # Semantic version, like 1.0.3-beta01+sha.22c35ffff166f34addc49a3b80e622b543199cc5
         # If the SemVer has metadata (after a +), then the full Semver will be added to the ReleaseNotes
@@ -131,9 +132,8 @@ function Build-Module {
         #   - Clean deletes the build output folder
         #   - Build builds the module output
         #   - CleanBuild first deletes the build output folder and then builds the module back into it
-        # Note that if you specify -VersionedOutputDirectory, the folder to be deleted is the version folder
-        # For -OutputDirectory ..\Output -SemVer 1.2.3 -Versioned the path to clean is ..\Output\ModuleName\1.2.3
-        # For -OutputDirectory ..\, the path to clean is ..\Output\ModuleName (the ..\Output path wouldn't be removed)
+        # Note that the folder to be deleted is the actual calculated output folder, with the version number
+        # So for the default OutputDirectory with version 1.2.3, the path to clean is: ..\Output\ModuleName\1.2.3
         [ValidateSet("Clean", "Build", "CleanBuild")]
         [string]$Target = "CleanBuild",
 

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -235,7 +235,7 @@ function Build-Module {
                 if ($Prerelease) {
                     Write-Verbose "Update Manifest at $OutputManifest with Prerelease: $Prerelease"
                     Update-Metadata -Path $OutputManifest -PropertyName PrivateData.PSData.Prerelease -Value $Prerelease
-                } else {
+                } elseif ($PSCmdlet.ParameterSetName -eq "SemanticVersion" -or $PSBoundParameters.ContainsKey("Prerelease")) {
                     Update-Metadata -Path $OutputManifest -PropertyName PrivateData.PSData.Prerelease -Value ""
                 }
             } elseif($Prerelease) {

--- a/Source/Public/Build-Module.ps1
+++ b/Source/Public/Build-Module.ps1
@@ -181,6 +181,10 @@ function Build-Module {
                     Where-Object LastWriteTime -gt $NewestBuild |
                     Select-Object -First 1 -ExpandProperty LastWriteTime
                 if ($null -eq $IsNew) {
+                    # This is mostly for testing ...
+                    if ($Passthru) {
+                        Get-Module $OutputManifest -ListAvailable
+                    }
                     return # Skip the build
                 }
             }

--- a/Source/Public/Convert-CodeCoverage.ps1
+++ b/Source/Public/Convert-CodeCoverage.ps1
@@ -2,6 +2,9 @@ function Convert-CodeCoverage {
     <#
         .SYNOPSIS
             Convert the file name and line numbers from Pester code coverage of "optimized" modules to the source
+        .DESCRIPTION
+            Converts the code coverage line numbers from Pester to the source file paths.
+            The returned file name is always the relative path stored in the module.
         .EXAMPLE
             Invoke-Pester .\Tests -CodeCoverage (Get-ChildItem .\Output -Filter *.psm1).FullName -PassThru |
                 Convert-CodeCoverage -SourceRoot .\Source -Relative

--- a/Tests/Convert-FolderSeparator.ps1
+++ b/Tests/Convert-FolderSeparator.ps1
@@ -1,7 +1,7 @@
-function global:Convert-FolderSeparator {
+filter global:Convert-FolderSeparator {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [string]$Path,
         [switch]$Relative,
         [switch]$Validate
@@ -34,6 +34,8 @@ function global:Convert-FolderSeparator {
         Write-Verbose "Result: $Result"
         $Path = $Path -replace ([regex]::escape($ConvertedPath)), $Result
     }
+    # if it's a testdrive path, it should be a testdrive path
+    $Path = $Path.Replace($TestDrive,"TestDrive:")
     if ($Drive) {
         $Path -replace "\w*:", "$($Drive):"
     } else {

--- a/Tests/Integration/Source1.Tests.ps1
+++ b/Tests/Integration/Source1.Tests.ps1
@@ -180,8 +180,8 @@ Describe "Regression test for #40.2 not copying suffix if prefix" -Tag Integrati
 
     $metadata = Import-Metadata TestDrive:\Source1\build.psd1
     $metadata += @{
-        Prefix = ".\_GlobalScope.ps1"
-        Suffix = ".\_GlobalScope.ps1"
+        Prefix = "./_GlobalScope.ps1"
+        Suffix = "./_GlobalScope.ps1"
     }
     $metadata | Export-Metadata TestDrive:\Source1\build.psd1
 
@@ -193,11 +193,11 @@ Describe "Regression test for #40.2 not copying suffix if prefix" -Tag Integrati
         $Module = [IO.Path]::ChangeExtension($Output.Path, "psm1")
         $Code = Get-Content $Module
         $Code[0] | Should -be "using module ModuleBuilder" # because we moved it, from GetFinale
-        $Code[1] | Should -be "#Region '.\_GlobalScope.ps1' 0"
+        $Code[1] | Should -be "#Region './_GlobalScope.ps1' 0"
         $Code[2] | Should -be '$Global:Module = "Testing"'
 
         $Code[-3] | Should -be '$Global:Module = "Testing"'
-        $Code[-2] | Should -be "#EndRegion '.\_GlobalScope.ps1' 2"
+        $Code[-2] | Should -be "#EndRegion './_GlobalScope.ps1' 2"
         $Code[-1] | Should -be ""
     }
 }

--- a/Tests/Integration/Source1/build.psd1
+++ b/Tests/Integration/Source1/build.psd1
@@ -1,5 +1,4 @@
 @{
     Path                     = "Source1.psd1"
     OutputDirectory          = "..\Result1"
-    VersionedOutputDirectory = $true
 }

--- a/Tests/Integration/build.psd1
+++ b/Tests/Integration/build.psd1
@@ -1,7 +1,6 @@
 @{
     Path                     = "Source1\Source1.psd1"
     OutputDirectory          = "..\Result1"
-    VersionedOutputDirectory = $true
 
     # This file is not in Source1 it's here next to this build
     Prefix                   = "..\using.ps1"

--- a/Tests/Private/GetRelativePath.Tests.ps1
+++ b/Tests/Private/GetRelativePath.Tests.ps1
@@ -1,0 +1,66 @@
+#requires -Module ModuleBuilder
+Describe "GetRelativePath" {
+    . $PSScriptRoot\..\Convert-FolderSeparator.ps1
+    $CommandInfo = InModuleScope ModuleBuilder { Get-Command GetRelativePath }
+
+    Context "All Parameters are mandatory" {
+
+        It "has a mandatory string RelativeTo parameter" {
+            $RelativeTo = $CommandInfo.Parameters['RelativeTo']
+            $RelativeTo | Should -Not -BeNullOrEmpty
+            $RelativeTo.ParameterType | Should -Be ([String])
+            $RelativeTo.Attributes.Where{ $_ -is [Parameter] }.Mandatory | Should -Be $True
+        }
+
+        It "has a mandatory string Path parameter" {
+            $Path = $CommandInfo.Parameters['Path']
+            $Path | Should -Not -BeNullOrEmpty
+            $Path.ParameterType | Should -Be ([string])
+            $Path.Attributes.Where{ $_ -is [Parameter] }.Mandatory | Should -Be $True
+        }
+    }
+
+    # I'm not going to bother writing tests for this other than "it's the same as .NET's"
+    if ([System.IO.Path]::GetRelativePath) {
+        Context "The output always matches [System.IO.Path]::GetRelativePath" {
+            $TestCases = @(
+                @{ RelativeTo = "G:\Module"; Path = "G:\Module\Source" }
+                @{ RelativeTo = "G:\Module"; Path = "G:\Module\Source\Public" }
+                @{ RelativeTo = "G:\Module\Source"; Path = "G:\Module\Output" }
+                @{ RelativeTo = "G:\Module\Source"; Path = "G:\Module\Output\" }
+                @{ RelativeTo = "G:\Module\Source\"; Path = "G:\Module\Output\" }
+                @{ RelativeTo = "G:\Module\Source\"; Path = "G:\Module\Output" }
+                @{ RelativeTo = "G:\Projects\Modules\MyModule\Source\Public"; Path = "G:\Modules\MyModule" }
+                @{ RelativeTo = "G:\Projects\Modules\MyModule\Source\Public"; Path = "G:\Projects\Modules\MyModule" }
+                # These ones are backwards, but they still work
+                @{ RelativeTo = "G:\Module\Source" ; Path = "G:\Module" }
+                @{ RelativeTo = "G:\Module\Source\Public"; Path = "G:\Module" }
+                # These are linux-like:
+                @{ RelativeTo = "/mnt/c/Users/Jaykul/Projects/Modules/ModuleBuilder"; Path = "/mnt/c/Users/Jaykul/Projects/Modules/ModuleBuilder/Source"; }
+                @{ RelativeTo = "/mnt/c/Users/Jaykul/Projects/Modules/ModuleBuilder"; Path = "/mnt/c/Users/Jaykul/Projects/Output"; }
+                @{ RelativeTo = "/mnt/c/Users/Jaykul/Projects/Modules/ModuleBuilder"; Path = "/mnt/c/Users/Jaykul/Projects/"; }
+                # Weird PowerShell Paths
+                @{ RelativeTo = "TestDrive:/Projects/Modules/ModuleBuilder"; Path = "TestDrive:\Projects" }
+                @{ RelativeTo = "TestDrive:/Projects/Modules/ModuleBuilder"; Path = "TestDrive:/Projects" }
+                @{ RelativeTo = "TestDrive:/Projects"; Path = "TestDrive:/Projects/Modules/ModuleBuilder" }
+            )
+
+            # On Windows, there's a shortcut when the path points to totally different drive letters:
+            if ($PSVersionTable.Platform -eq "Win32NT") {
+                $TestCases += @(
+                    @{ RelativeTo = "G:\Projects\Modules\MyModule\Source\Public"; Path = "C:\Modules\MyModule" }
+                    @{ RelativeTo = "G:\Projects\Modules\MyModule\Source\Public"; Path = "F:\Projects\Modules\MyModule" }
+                )
+            }
+
+            It "Returns the same result as Path.GetRelativePath for <Path>" -TestCases $TestCases {
+                param($RelativeTo, $Path)
+                $RelativeTo = Convert-FolderSeparator $RelativeTo
+                $Path = Convert-FolderSeparator $Path
+                # Write-Verbose $Path -Verbose
+                $Expected = [System.IO.Path]::GetRelativePath($RelativeTo, $Path)
+                & $CommandInfo $RelativeTo $Path | Should -Be $Expected
+            }
+        }
+    }
+}

--- a/Tests/Private/InitializeBuild.Tests.ps1
+++ b/Tests/Private/InitializeBuild.Tests.ps1
@@ -26,6 +26,8 @@ Describe "InitializeBuild" {
                         $SourcePath = ".\Source",
                         $SourceDirectories = @("Enum", "Classes", "Private", "Public"),
                         $OutputDirectory = ".\Output",
+                        $VersionedOutputDirectory = $true,
+                        $UnversionedOutputDirectory = $true,
                         $Suffix
                     )
                     try {
@@ -61,6 +63,10 @@ Describe "InitializeBuild" {
 
         It "Returns overriden values from parameters" {
             $Result.SourcePath | Should -Be (Convert-Path 'TestDrive:\Source\MyModule.psd1')
+        }
+
+        It "Sets VersionedOutputDirectory FALSE when UnversionedOutputDirectory is TRUE" {
+            $Result.VersionedOutputDirectory | Should -Be $false
         }
     }
 }

--- a/Tests/Private/ResolveOutputFolder.Tests.ps1
+++ b/Tests/Private/ResolveOutputFolder.Tests.ps1
@@ -5,16 +5,6 @@ Describe "ResolveOutputFolder" {
     filter ToTestDrive { "$_".Replace($TestDrive, "TestDrive:") }
 
     $TestCases = [Hashtable[]]@(
-        @{  Source = "Source"
-            Output = "Output"
-            Result = "Output/ModuleName"
-            Forced = "Output/ModuleName/1.2.3"
-        }
-        @{  Output = "ModuleName/Output"
-            Source = "ModuleName/Source"
-            Result = "ModuleName/Output/ModuleName"
-            Forced = "ModuleName/Output/ModuleName/1.2.3"
-        }
         @{  # Be like Jaykul
             Source = "ModuleName/Source"
             Output = "ModuleName"
@@ -26,6 +16,18 @@ Describe "ResolveOutputFolder" {
             Output = "1/b"
             Result = "1/b/ModuleName"
             Forced = "1/b/ModuleName/1.2.3"
+        }
+        @{  # The default option would be Module/Source build to Module/Output
+            Source = "ModuleName/Source"
+            Output = "ModuleName/Output"
+            Result = "ModuleName/Output/ModuleName"
+            Forced = "ModuleName/Output/ModuleName/1.2.3"
+        }
+        @{  # Which is the same even without the common named parent
+            Source = "Source"
+            Output = "Output"
+            Result = "Output/ModuleName"
+            Forced = "Output/ModuleName/1.2.3"
         }
         @{  # An edge case, build straight to a modules folder
             Source = "ModuleName/Source"
@@ -57,8 +59,8 @@ Describe "ResolveOutputFolder" {
             param($Source, $Output, $Result)
 
             $Parameters = @{
-                Source = Convert-FolderSeparator "TestDrive:/$Source"
-                Output = Convert-FolderSeparator "TestDrive:/$Output"
+                Source = Convert-FolderSeparator "$TestDrive/$Source"
+                Output = Convert-FolderSeparator "$TestDrive/$Output"
             }
 
             $Actual = &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 | ToTestDrive

--- a/Tests/Private/ResolveOutputFolder.Tests.ps1
+++ b/Tests/Private/ResolveOutputFolder.Tests.ps1
@@ -1,5 +1,6 @@
 #requires -Module ModuleBuilder
 Describe "ResolveOutputFolder" {
+    . $PSScriptRoot\..\Convert-FolderSeparator.ps1
     $CommandInTest = InModuleScope ModuleBuilder { Get-Command ResolveOutputFolder }
     filter ToTestDrive { "$_".Replace($TestDrive, "TestDrive:") }
 
@@ -56,26 +57,26 @@ Describe "ResolveOutputFolder" {
             param($Source, $Output, $Result)
 
             $Parameters = @{
-                Source = "TestDrive:/$Source"
-                Output = "TestDrive:/$Output"
+                Source = Convert-FolderSeparator "TestDrive:/$Source"
+                Output = Convert-FolderSeparator "TestDrive:/$Output"
             }
 
             $Actual = &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 | ToTestDrive
             $Actual | Should -Exist
-            $Actual | Should -Be "TestDrive:/$Result"
+            $Actual | Should -Be (Convert-FolderSeparator "TestDrive:/$Result")
         }
 
         It "From '<Source>' to '<Output>' -ForceVersion creates '<Forced>'" -TestCases $TestCases {
             param($Source, $Output, $Forced)
 
             $Parameters = @{
-                Source = "TestDrive:/$Source"
-                Output = "TestDrive:/$Output"
+                Source = Convert-FolderSeparator "TestDrive:/$Source"
+                Output = Convert-FolderSeparator "TestDrive:/$Output"
             }
 
             $Actual = &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 -Force | ToTestDrive
             $Actual | Should -Exist
-            $Actual | Should -Be "TestDrive:/$Forced"
+            $Actual | Should -Be (Convert-FolderSeparator "TestDrive:/$Forced")
         }
     }
     Context "Cleaned ModuleName" {
@@ -83,11 +84,11 @@ Describe "ResolveOutputFolder" {
             param($Source, $Output, $Result)
 
             $Parameters = @{
-                Source = "TestDrive:/$Source"
-                Output = "TestDrive:/$Output"
+                Source = Convert-FolderSeparator "TestDrive:/$Source"
+                Output = Convert-FolderSeparator "TestDrive:/$Output"
             }
 
-            $null = New-Item -ItemType Directory "TestDrive:/$Result" -Force
+            $null = New-Item -ItemType Directory (Convert-FolderSeparator "TestDrive:/$Result") -Force
 
             # There's no output when we're cleaning
             &$CommandInTest @Parameters -Name ModuleName -Version 1.2.3 -Target Clean | Should -BeNullOrEmpty
@@ -100,16 +101,16 @@ Describe "ResolveOutputFolder" {
             param($Source, $Output, $Forced)
 
             $Parameters = @{
-                Source = "TestDrive:/$Source"
-                Output = "TestDrive:/$Output"
+                Source = Convert-FolderSeparator "TestDrive:/$Source"
+                Output = Convert-FolderSeparator "TestDrive:/$Output"
             }
             $null = New-Item -ItemType Directory "TestDrive:/$Forced" -Force
 
             # There's no output when we're cleaning
             &$CommandInTest @Parameters -Name ModuleName -Version 1.2.3 -Force -Target Clean | Should -BeNullOrEmpty
-            "TestDrive:/$Forced" | Should -Not -Exist
+            "TestDrive:/$Forced" | Convert-FolderSeparator | Should -Not -Exist
             # NOTE: This is only true because we made it above
-            "TestDrive:/$Forced" | Split-Path | Should -Exist
+            "TestDrive:/$Forced" | Convert-FolderSeparator | Split-Path | Should -Exist
         }
     }
     Context "Error Cases" {
@@ -118,8 +119,8 @@ Describe "ResolveOutputFolder" {
             New-Item TestDrive:/ModuleName/1.2.3 -ItemType File -Value "Hello World"
 
             $Parameters = @{
-                Source = "TestDrive:/ModuleName/Source"
-                Output = "TestDrive:/ModuleName/"
+                Source = Convert-FolderSeparator "TestDrive:/ModuleName/Source"
+                Output = Convert-FolderSeparator "TestDrive:/ModuleName/"
             }
 
             { &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 -Force } | Should -throw "There is a file in the way"

--- a/Tests/Private/ResolveOutputFolder.Tests.ps1
+++ b/Tests/Private/ResolveOutputFolder.Tests.ps1
@@ -1,70 +1,128 @@
 #requires -Module ModuleBuilder
 Describe "ResolveOutputFolder" {
+    $CommandInTest = InModuleScope ModuleBuilder { Get-Command ResolveOutputFolder }
+    filter ToTestDrive { "$_".Replace($TestDrive, "TestDrive:") }
 
-    Context "Given an OutputDirectory and ModuleBase" {
+    $TestCases = [Hashtable[]]@(
+        @{  Source = "Source"
+            Output = "Output"
+            Result = "Output\ModuleName"
+            Forced = "Output\ModuleName\1.2.3"
+        }
+        @{  Output = "ModuleName\Output"
+            Source = "ModuleName\Source"
+            Result = "ModuleName\Output\ModuleName"
+            Forced = "ModuleName\Output\ModuleName\1.2.3"
+        }
+        @{  # Be like Jaykul
+            Source = "ModuleName\Source"
+            Output = "ModuleName"
+            Result = "ModuleName\1.2.3"
+            Forced = "ModuleName\1.2.3"
+        }
+        @{  # Be like azure
+            Source = "1\s"
+            Output = "1\b"
+            Result = "1\b\ModuleName"
+            Forced = "1\b\ModuleName\1.2.3"
+        }
+        @{  # An edge case, build straight to a modules folder
+            Source = "ModuleName\Source"
+            Output = "Modules"
+            Result = "Modules\ModuleName"
+            Forced = "Modules\ModuleName\1.2.3"
+        }
+        @{  # What if they pass in the correct path ahead of time?
+            Source = "1\s"
+            Output = "1\b\ModuleName"
+            Result = "1\b\ModuleName"
+            Forced = "1\b\ModuleName\1.2.3"
+        }
+        @{  # What if they pass in the correct path ahead of time?
+            Source = "1\s"
+            Output = "1\b\ModuleName\1.2.3"
+            Result = "1\b\ModuleName\1.2.3"
+            Forced = "1\b\ModuleName\1.2.3"
+        }
+        @{  # Super edge case: what if they pass in an incorrectly versioned output path?
+            Source = "1\s"
+            Output = "1\b\ModuleName\4.5.6"
+            Result = "1\b\ModuleName\4.5.6\ModuleName"
+            Forced = "1\b\ModuleName\4.5.6\ModuleName\1.2.3"
+        }
+    )
+    Context "Build ModuleName" {
+        It "From '<Source>' to '<Output>' creates '<Result>'" -TestCases $TestCases {
+            param($Source, $Output, $Result)
 
-        $Result = InModuleScope -ModuleName ModuleBuilder {
-            ResolveOutputFolder -OutputDirectory TestDrive:\Output -ModuleBase TestDrive:\Source
+            $Parameters = @{
+                Source = "TestDrive:\$Source"
+                Output = "TestDrive:\$Output"
+            }
+
+            $Actual = &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 | ToTestDrive
+            $Actual | Should -Exist
+            $Actual | Should -Be "TestDrive:\$Result"
         }
 
-        It "Creates the Output directory" {
-            $Result | Should -Be (Convert-Path "TestDrive:\Output")
-            $Result | Should -Exist
+        It "From '<Source>' to '<Output>' -ForceVersion creates '<Forced>'" -TestCases $TestCases {
+            param($Source, $Output, $Forced)
+
+            $Parameters = @{
+                Source = "TestDrive:\$Source"
+                Output = "TestDrive:\$Output"
+            }
+
+            $Actual = &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 -Force | ToTestDrive
+            $Actual | Should -Exist
+            $Actual | Should -Be "TestDrive:\$Forced"
         }
     }
+    Context "Cleaned ModuleName" {
+        It "From '<Source>' to '<Output>' deletes '<Result>'" -TestCases $TestCases {
+            param($Source, $Output, $Result)
 
-    Context "Given an OutputDirectory, ModuleBase and ModuleVersion but no switch" {
+            $Parameters = @{
+                Source = "TestDrive:\$Source"
+                Output = "TestDrive:\$Output"
+            }
 
-        $Result = InModuleScope -ModuleName ModuleBuilder {
-            ResolveOutputFolder -OutputDirectory TestDrive:\Output -ModuleVersion "1.0.0" -ModuleBase TestDrive:\Source
+            $null = mkdir "TestDrive:\$Result" -Force
+
+            # There's no output when we're cleaning
+            &$CommandInTest @Parameters -Name ModuleName -Version 1.2.3 -Target Clean | Should -BeNullOrEmpty
+            "TestDrive:\$Result" | Should -Not -Exist
+            # NOTE: This is only true because we made it above
+            "TestDrive:\$Result" | Split-Path | Should -Exist
         }
 
-        It "Creates the Output directory" {
-            "TestDrive:\Output" | Should -Exist
-        }
+        It "From '<Source>' to '<Output>' -ForceVersion deletes '<Forced>'" -TestCases $TestCases {
+            param($Source, $Output, $Forced)
 
-        It "Returns the Output directory" {
-            $Result | Should -Be (Convert-Path "TestDrive:\Output")
-        }
+            $Parameters = @{
+                Source = "TestDrive:\$Source"
+                Output = "TestDrive:\$Output"
+            }
+            $null = mkdir "TestDrive:\$Forced" -Force
 
-        It "Does not creates children in Output" {
-            Get-ChildItem $Result | Should -BeNullOrEmpty
-        }
-    }
-
-    Context "Given an OutputDirectory, ModuleBase, ModuleVersion and switch" {
-
-        $Result = InModuleScope -ModuleName ModuleBuilder {
-            ResolveOutputFolder -OutputDirectory TestDrive:\Output -ModuleVersion "1.0.0" -VersionedOutput -ModuleBase TestDrive:\Source
-        }
-
-        It "Creates the Output directory" {
-            "TestDrive:\Output" | Should -Exist
-        }
-
-        It "Creates the version directory" {
-            "TestDrive:\Output\1.0.0" | Should -Exist
-        }
-
-        It "Returns the Output directory" {
-            $Result | Should -Be (Convert-Path "TestDrive:\Output\1.0.0")
+            # There's no output when we're cleaning
+            &$CommandInTest @Parameters -Name ModuleName -Version 1.2.3 -Force -Target Clean | Should -BeNullOrEmpty
+            "TestDrive:\$Forced" | Should -Not -Exist
+            # NOTE: This is only true because we made it above
+            "TestDrive:\$Forced" | Split-Path | Should -Exist
         }
     }
+    Context "Error Cases" {
+        It "Won't remove a file that blocks the folder path" {
+            $null = mkdir TestDrive:\ModuleName\Source -force
+            New-Item TestDrive:\ModuleName\1.2.3 -ItemType File -Value "Hello World"
 
-    Context "Given a relative OutputDirectory, the Folder is created relative to ModuleBase" {
+            $Parameters = @{
+                Source = "TestDrive:\ModuleName\Source"
+                Output = "TestDrive:\ModuleName\"
+            }
 
-
-        $Result = InModuleScope -ModuleName ModuleBuilder {
-            ResolveOutputFolder -OutputDirectory '..\Output' -ModuleBase TestDrive:\Source
+            { &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 -Force } | Should -throw "There is a file in the way"
         }
-
-        It "Returns an absolute FileSystem path" {
-            { [io.path]::IsPathRooted($Result) } | Should -Not -Throw
-        }
-
-        It "has created the Folder" {
-            (Test-Path $Result) | Should -Be $True
-        }
-
     }
 }

--- a/Tests/Private/ResolveOutputFolder.Tests.ps1
+++ b/Tests/Private/ResolveOutputFolder.Tests.ps1
@@ -6,49 +6,49 @@ Describe "ResolveOutputFolder" {
     $TestCases = [Hashtable[]]@(
         @{  Source = "Source"
             Output = "Output"
-            Result = "Output\ModuleName"
-            Forced = "Output\ModuleName\1.2.3"
+            Result = "Output/ModuleName"
+            Forced = "Output/ModuleName/1.2.3"
         }
-        @{  Output = "ModuleName\Output"
-            Source = "ModuleName\Source"
-            Result = "ModuleName\Output\ModuleName"
-            Forced = "ModuleName\Output\ModuleName\1.2.3"
+        @{  Output = "ModuleName/Output"
+            Source = "ModuleName/Source"
+            Result = "ModuleName/Output/ModuleName"
+            Forced = "ModuleName/Output/ModuleName/1.2.3"
         }
         @{  # Be like Jaykul
-            Source = "ModuleName\Source"
+            Source = "ModuleName/Source"
             Output = "ModuleName"
-            Result = "ModuleName\1.2.3"
-            Forced = "ModuleName\1.2.3"
+            Result = "ModuleName/1.2.3"
+            Forced = "ModuleName/1.2.3"
         }
         @{  # Be like azure
-            Source = "1\s"
-            Output = "1\b"
-            Result = "1\b\ModuleName"
-            Forced = "1\b\ModuleName\1.2.3"
+            Source = "1/s"
+            Output = "1/b"
+            Result = "1/b/ModuleName"
+            Forced = "1/b/ModuleName/1.2.3"
         }
         @{  # An edge case, build straight to a modules folder
-            Source = "ModuleName\Source"
+            Source = "ModuleName/Source"
             Output = "Modules"
-            Result = "Modules\ModuleName"
-            Forced = "Modules\ModuleName\1.2.3"
+            Result = "Modules/ModuleName"
+            Forced = "Modules/ModuleName/1.2.3"
         }
         @{  # What if they pass in the correct path ahead of time?
-            Source = "1\s"
-            Output = "1\b\ModuleName"
-            Result = "1\b\ModuleName"
-            Forced = "1\b\ModuleName\1.2.3"
+            Source = "1/s"
+            Output = "1/b/ModuleName"
+            Result = "1/b/ModuleName"
+            Forced = "1/b/ModuleName/1.2.3"
         }
         @{  # What if they pass in the correct path ahead of time?
-            Source = "1\s"
-            Output = "1\b\ModuleName\1.2.3"
-            Result = "1\b\ModuleName\1.2.3"
-            Forced = "1\b\ModuleName\1.2.3"
+            Source = "1/s"
+            Output = "1/b/ModuleName/1.2.3"
+            Result = "1/b/ModuleName/1.2.3"
+            Forced = "1/b/ModuleName/1.2.3"
         }
         @{  # Super edge case: what if they pass in an incorrectly versioned output path?
-            Source = "1\s"
-            Output = "1\b\ModuleName\4.5.6"
-            Result = "1\b\ModuleName\4.5.6\ModuleName"
-            Forced = "1\b\ModuleName\4.5.6\ModuleName\1.2.3"
+            Source = "1/s"
+            Output = "1/b/ModuleName/4.5.6"
+            Result = "1/b/ModuleName/4.5.6/ModuleName"
+            Forced = "1/b/ModuleName/4.5.6/ModuleName/1.2.3"
         }
     )
     Context "Build ModuleName" {
@@ -56,26 +56,26 @@ Describe "ResolveOutputFolder" {
             param($Source, $Output, $Result)
 
             $Parameters = @{
-                Source = "TestDrive:\$Source"
-                Output = "TestDrive:\$Output"
+                Source = "TestDrive:/$Source"
+                Output = "TestDrive:/$Output"
             }
 
             $Actual = &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 | ToTestDrive
             $Actual | Should -Exist
-            $Actual | Should -Be "TestDrive:\$Result"
+            $Actual | Should -Be "TestDrive:/$Result"
         }
 
         It "From '<Source>' to '<Output>' -ForceVersion creates '<Forced>'" -TestCases $TestCases {
             param($Source, $Output, $Forced)
 
             $Parameters = @{
-                Source = "TestDrive:\$Source"
-                Output = "TestDrive:\$Output"
+                Source = "TestDrive:/$Source"
+                Output = "TestDrive:/$Output"
             }
 
             $Actual = &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 -Force | ToTestDrive
             $Actual | Should -Exist
-            $Actual | Should -Be "TestDrive:\$Forced"
+            $Actual | Should -Be "TestDrive:/$Forced"
         }
     }
     Context "Cleaned ModuleName" {
@@ -83,43 +83,43 @@ Describe "ResolveOutputFolder" {
             param($Source, $Output, $Result)
 
             $Parameters = @{
-                Source = "TestDrive:\$Source"
-                Output = "TestDrive:\$Output"
+                Source = "TestDrive:/$Source"
+                Output = "TestDrive:/$Output"
             }
 
-            $null = mkdir "TestDrive:\$Result" -Force
+            $null = New-Item -ItemType Directory "TestDrive:/$Result" -Force
 
             # There's no output when we're cleaning
             &$CommandInTest @Parameters -Name ModuleName -Version 1.2.3 -Target Clean | Should -BeNullOrEmpty
-            "TestDrive:\$Result" | Should -Not -Exist
+            "TestDrive:/$Result" | Should -Not -Exist
             # NOTE: This is only true because we made it above
-            "TestDrive:\$Result" | Split-Path | Should -Exist
+            "TestDrive:/$Result" | Split-Path | Should -Exist
         }
 
         It "From '<Source>' to '<Output>' -ForceVersion deletes '<Forced>'" -TestCases $TestCases {
             param($Source, $Output, $Forced)
 
             $Parameters = @{
-                Source = "TestDrive:\$Source"
-                Output = "TestDrive:\$Output"
+                Source = "TestDrive:/$Source"
+                Output = "TestDrive:/$Output"
             }
-            $null = mkdir "TestDrive:\$Forced" -Force
+            $null = New-Item -ItemType Directory "TestDrive:/$Forced" -Force
 
             # There's no output when we're cleaning
             &$CommandInTest @Parameters -Name ModuleName -Version 1.2.3 -Force -Target Clean | Should -BeNullOrEmpty
-            "TestDrive:\$Forced" | Should -Not -Exist
+            "TestDrive:/$Forced" | Should -Not -Exist
             # NOTE: This is only true because we made it above
-            "TestDrive:\$Forced" | Split-Path | Should -Exist
+            "TestDrive:/$Forced" | Split-Path | Should -Exist
         }
     }
     Context "Error Cases" {
         It "Won't remove a file that blocks the folder path" {
-            $null = mkdir TestDrive:\ModuleName\Source -force
-            New-Item TestDrive:\ModuleName\1.2.3 -ItemType File -Value "Hello World"
+            $null = New-Item -ItemType Directory TestDrive:/ModuleName/Source -force
+            New-Item TestDrive:/ModuleName/1.2.3 -ItemType File -Value "Hello World"
 
             $Parameters = @{
-                Source = "TestDrive:\ModuleName\Source"
-                Output = "TestDrive:\ModuleName\"
+                Source = "TestDrive:/ModuleName/Source"
+                Output = "TestDrive:/ModuleName/"
             }
 
             { &$CommandInTest @Parameters -Name ModuleName -Target Build -Version 1.2.3 -Force } | Should -throw "There is a file in the way"

--- a/Tests/Public/Build-Module.Tests.ps1
+++ b/Tests/Public/Build-Module.Tests.ps1
@@ -1,4 +1,10 @@
+#requires -Module ModuleBuilder
 Describe "Build-Module" {
+    . $PSScriptRoot\..\Convert-FolderSeparator.ps1
+    $PSDefaultParameterValues = @{
+        "Mock:ModuleName" = "ModuleBuilder"
+        "Assert-MockCalled:ModuleName" = "ModuleBuilder"
+    }
 
     Context "Parameter Binding" {
 
@@ -73,12 +79,42 @@ Describe "Build-Module" {
         }
     }
 
+    InModuleScope ModuleBuilder {
+        Mock MoveUsingStatements
+        Mock SetModuleContent
+    }
+    Mock Update-Metadata
+    Mock Copy-Item
+    Mock Set-Location
+
+    Mock Join-Path {
+        [IO.Path]::Combine($Path, $ChildPath)
+    }
+
+    Mock Get-Metadata {
+        "First Release"
+    }
+
+    $global:Mock_OutputPath = Convert-FolderSeparator "TestDrive:/Output/MyModule"
+
+    Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
+        (Convert-FolderSeparator "$Path") -eq $Mock_OutputPath -and
+        $ItemType -eq "Directory" -and $Force
+    }
+
+    Mock Test-Path { $True } -Parameter {
+        (Convert-FolderSeparator "$Path") -eq $Mock_OutputPath -and ($PathType -notin "Any", "Leaf")
+    }
+
+    Mock Remove-Item -Parameter {
+        (Convert-FolderSeparator "$Path") -eq $Mock_OutputPath
+    }
+
     Context "When run without parameters" {
         Push-Location TestDrive:/ -StackName BuildModuleTest
         New-Item -ItemType Directory -Path TestDrive:/Output/MyModule/1.0.0/ -Force
 
-        Mock SetModuleContent -ModuleName ModuleBuilder {}
-        Mock ConvertToAst -ModuleName ModuleBuilder {
+        Mock ConvertToAst {
             [PSCustomObject]@{
                 PSTypeName  = "PoshCode.ModuleBuilder.ParseResults"
                 ParseErrors = $null
@@ -86,10 +122,8 @@ Describe "Build-Module" {
                 AST         = { }.AST
             }
         }
-        Mock GetCommandAlias -ModuleName ModuleBuilder { @{'Get-MyInfo' = @('GMI') } }
-        Mock MoveUsingStatements -ModuleName ModuleBuilder {}
-        Mock Update-Metadata -ModuleName ModuleBuilder {}
-        Mock InitializeBuild -ModuleName ModuleBuilder {
+        Mock GetCommandAlias { @{'Get-MyInfo' = @('GMI') } }
+        Mock InitializeBuild {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:/Output"
@@ -103,20 +137,13 @@ Describe "Build-Module" {
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
-            $Path -eq "TestDrive:/Output/MyModule" -and
-            $ItemType -eq "Directory" -and
-            $Force -eq $true
-        } -ModuleName ModuleBuilder
 
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:/Output/MyModule" } -ModuleName ModuleBuilder
-        Mock Push-Location {} -ModuleName ModuleBuilder
-        Mock Copy-Item {} -ModuleName ModuleBuilder
+
+        Mock Push-Location {}
 
         Mock Get-ChildItem {
             [IO.FileInfo]"$TestDrive/Output/MyModule/Public/Get-MyInfo.ps1"
-        } -ModuleName ModuleBuilder
+        }
 
 
         try {
@@ -127,41 +154,41 @@ Describe "Build-Module" {
 
         # NOTE: We're not just clearing output, but the whole folder
         It "Should remove the output folder if it exists" {
-            Assert-MockCalled Remove-Item -ModuleName ModuleBuilder
+            Assert-MockCalled Remove-Item
         }
 
         It "Should always (re)create the OutputDirectory" {
-            Assert-MockCalled New-Item -ModuleName ModuleBuilder
+            Assert-MockCalled New-Item
         }
 
         It "Should run in the module source folder" {
-            Assert-MockCalled Push-Location -ModuleName ModuleBuilder -Parameter {
+            Assert-MockCalled Push-Location -Parameter {
                 $Path -eq "TestDrive:/MyModule/"
             }
         }
 
         It "Should call ConvertToAst to parse the module" {
-            Assert-MockCalled ConvertToAst -ModuleName ModuleBuilder
+            Assert-MockCalled ConvertToAst
         }
 
         It "Should call MoveUsingStatements to move the using statements, just in case" {
-            Assert-MockCalled MoveUsingStatements -ModuleName ModuleBuilder -Parameter {
+            Assert-MockCalled MoveUsingStatements -Parameter {
                 $AST.Extent.Text -eq "{ }"
             }
         }
 
         It "Should call SetModuleContent to combine the source files" {
-            Assert-MockCalled SetModuleContent -ModuleName ModuleBuilder
+            Assert-MockCalled SetModuleContent
         }
 
         It "Should call Update-Metadata to set the FunctionsToExport" {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -Parameter {
+            Assert-MockCalled Update-Metadata -Parameter {
                 $PropertyName -eq "FunctionsToExport"
             }
         }
 
         It "Should call Update-Metadata to set the AliasesToExport" {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -Parameter {
+            Assert-MockCalled Update-Metadata -Parameter {
                 $PropertyName -eq "AliasesToExport"
             }
         }
@@ -175,9 +202,7 @@ Describe "Build-Module" {
         New-Item -ItemType Directory -Path TestDrive:/1.0.0/ -Force
         New-Item -ItemType File -Path TestDrive:/1.0.0/MyModule.psm1 -Force
 
-        Mock SetModuleContent -ModuleName ModuleBuilder {}
-        Mock Update-Metadata -ModuleName ModuleBuilder {}
-        Mock InitializeBuild -ModuleName ModuleBuilder {
+        Mock InitializeBuild {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:/Output"
@@ -191,25 +216,15 @@ Describe "Build-Module" {
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
-            $Path -eq "TestDrive:/Output/MyModule" -and
-            $ItemType -eq "Directory" -and
-            $Force -eq $true
-        } -ModuleName ModuleBuilder
-        Mock Convert-Path { $Path } -ModuleName ModuleBuilder
-
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:/Output/MyModule" } -ModuleName ModuleBuilder
-        Mock Set-Location {} -ModuleName ModuleBuilder
-        Mock Copy-Item {} -ModuleName ModuleBuilder
+        Mock Convert-Path { $Path }
 
         Mock Get-ChildItem {
             [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
-        } -ModuleName ModuleBuilder
+        }
 
         Mock Get-Item {
             [PSCustomObject]@{ LastWriteTime = Get-Date }
-        } -ModuleName ModuleBuilder
+        }
 
         try {
             Build-Module -Target Build
@@ -219,19 +234,19 @@ Describe "Build-Module" {
 
         # NOTE: We're not just clearing output, but the whole folder
         It "Should NOT remove the output folder" {
-            Assert-MockCalled Remove-Item -ModuleName ModuleBuilder -Times 0
+            Assert-MockCalled Remove-Item -Times 0
         }
 
         It "Should check the dates on the output" {
-            Assert-MockCalled Get-Item -ModuleName ModuleBuilder -Times 1
+            Assert-MockCalled Get-Item -Times 1
         }
 
         It "Should always (re)create the OutputDirectory" {
-            Assert-MockCalled New-Item -ModuleName ModuleBuilder -Times 1
+            Assert-MockCalled New-Item -Times 1
         }
 
         It "Should not rebuild the source files" {
-            Assert-MockCalled SetModuleContent -ModuleName ModuleBuilder -Times 0
+            Assert-MockCalled SetModuleContent -Times 0
         }
     }
 
@@ -242,10 +257,7 @@ Describe "Build-Module" {
         New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
         New-Item -ItemType Directory -Path "TestDrive:/Output/MyModule/$ExpectedVersion" -Force
 
-        Mock SetModuleContent -ModuleName ModuleBuilder {}
-        Mock Update-Metadata -ModuleName ModuleBuilder {}
-
-        Mock InitializeBuild -ModuleName ModuleBuilder {
+        Mock InitializeBuild {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:/Output"
@@ -260,27 +272,11 @@ Describe "Build-Module" {
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule/$ExpectedVersion") } -Parameter {
-            $Path -eq "TestDrive:/Output/MyModule/$ExpectedVersion" -and
-            $ItemType -eq "Directory" -and
-            $Force -eq $true
-        } -ModuleName ModuleBuilder
-
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule/$ExpectedVersion" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter {
-            $Path -eq "TestDrive:/Output/MyModule/1.0.0"
-        } -ModuleName ModuleBuilder
-        Mock Set-Location {} -ModuleName ModuleBuilder
-        Mock Copy-Item {} -ModuleName ModuleBuilder
-        # Release notes
-        Mock Get-Metadata { "First Release" } -ModuleName ModuleBuilder
-        Mock Join-Path {
-            [IO.Path]::Combine($Path, $ChildPath)
-        } -ModuleName ModuleBuilder
+        $global:Mock_OutputPath = Convert-FolderSeparator "TestDrive:/Output/MyModule/$ExpectedVersion"
 
         Mock Get-ChildItem {
             [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
-        } -ModuleName ModuleBuilder
+        }
 
         try {
             Build-Module -SemVer $SemVer
@@ -290,29 +286,29 @@ Describe "Build-Module" {
         }
 
         It "Should build to an output folder with the simple version." {
-            Assert-MockCalled Remove-Item -ModuleName ModuleBuilder
-            Assert-MockCalled New-Item -ModuleName ModuleBuilder
+            Assert-MockCalled Remove-Item
+            Assert-MockCalled New-Item
         }
 
         It "Should update the module version to the simple version." {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "ModuleVersion" -and $Value -eq $ExpectedVersion
             }
         }
         It "Should update the module pre-release version" {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.Prerelease" -and $Value -eq "beta03"
             }
         }
         It "When there are simple release notes, it should insert a line with the module name and full semver" {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.ReleaseNotes" -and $Value -eq "MyModule v$($SemVer)`nFirst Release"
             }
         }
 
         It "When there's no release notes, it should insert the module name and full semver" {
             # If there's no release notes, but it was left uncommented
-            Mock Get-Metadata { "" } -ModuleName ModuleBuilder
+            Mock Get-Metadata { "" }
 
             try {
                 Build-Module -SemVer $SemVer
@@ -321,7 +317,7 @@ Describe "Build-Module" {
                 throw
             }
 
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.ReleaseNotes" -and $Value -eq "MyModule v$SemVer"
             }
         }
@@ -330,7 +326,7 @@ Describe "Build-Module" {
             # If there's no release notes, but it was left uncommented
             Mock Get-Metadata { "
                     Multi-line Release Notes
-                    With a prefix carriage return" } -ModuleName ModuleBuilder
+                    With a prefix carriage return" }
 
             try {
                 Build-Module -SemVer $SemVer
@@ -339,7 +335,7 @@ Describe "Build-Module" {
                 throw
             }
 
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.ReleaseNotes" -and $Value -eq "
                     MyModule v$SemVer
                     Multi-line Release Notes
@@ -362,10 +358,7 @@ Describe "Build-Module" {
         New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
         New-Item -ItemType Directory -Path "TestDrive:/Output/MyModule/$ExpectedVersion" -Force
 
-        Mock SetModuleContent -ModuleName ModuleBuilder {}
-        Mock Update-Metadata -ModuleName ModuleBuilder {}
-
-        Mock InitializeBuild -ModuleName ModuleBuilder {
+        Mock InitializeBuild {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:/Output"
@@ -379,25 +372,10 @@ Describe "Build-Module" {
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
-            $Path -eq "TestDrive:/Output/MyModule" -and
-            $ItemType -eq "Directory" -and
-            $Force -eq $true
-        } -ModuleName ModuleBuilder
-
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter {$Path -eq "TestDrive:/Output/MyModule"} -ModuleName ModuleBuilder
-        Mock Set-Location {} -ModuleName ModuleBuilder
-        Mock Copy-Item {} -ModuleName ModuleBuilder
-        # Release notes
-        Mock Get-Metadata { "First Release" } -ModuleName ModuleBuilder
-        Mock Join-Path {
-            [IO.Path]::Combine($Path, $ChildPath)
-        } -ModuleName ModuleBuilder
-
+        $global:Mock_OutputPath = Convert-FolderSeparator "TestDrive:/Output/MyModule"
         Mock Get-ChildItem {
             [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
-        } -ModuleName ModuleBuilder
+        }
 
         try {
             Build-Module @SemVer
@@ -407,22 +385,22 @@ Describe "Build-Module" {
         }
 
         It "Should build to an output folder with the simple version." {
-            Assert-MockCalled Remove-Item -ModuleName ModuleBuilder
-            Assert-MockCalled New-Item -ModuleName ModuleBuilder
+            Assert-MockCalled Remove-Item
+            Assert-MockCalled New-Item
         }
 
         It "Should update the module version to the simple version." {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "ModuleVersion" -and $Value -eq $ExpectedVersion
             }
         }
         It "Should update the module pre-release version" {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.Prerelease" -and $Value -eq "beta03"
             }
         }
         It "When there are simple release notes, it should insert a line with the module name and full semver" {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.ReleaseNotes" -and
                     $Value -eq "MyModule v$($SemVer.Version)-$($SemVer.Prerelease)+$($SemVer.BuildMetadata)`nFirst Release"
             }
@@ -430,7 +408,7 @@ Describe "Build-Module" {
 
         It "When there's no release notes, it should insert the module name and full semver" {
             # If there's no release notes, but it was left uncommented
-            Mock Get-Metadata { "" } -ModuleName ModuleBuilder
+            Mock Get-Metadata { "" }
 
             try {
                 Build-Module @SemVer
@@ -439,7 +417,7 @@ Describe "Build-Module" {
                 throw
             }
 
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.ReleaseNotes" -and
                     $Value -eq "MyModule v$($SemVer.Version)-$($SemVer.Prerelease)+$($SemVer.BuildMetadata)"
             }
@@ -449,7 +427,7 @@ Describe "Build-Module" {
             # If there's no release notes, but it was left uncommented
             Mock Get-Metadata { "
                     Multi-line Release Notes
-                    With a prefix carriage return" } -ModuleName ModuleBuilder
+                    With a prefix carriage return" }
 
             try {
                 Build-Module @SemVer
@@ -458,7 +436,7 @@ Describe "Build-Module" {
                 throw
             }
 
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.ReleaseNotes" -and $Value -eq "
                     MyModule v$($SemVer.Version)-$($SemVer.Prerelease)+$($SemVer.BuildMetadata)
                     Multi-line Release Notes
@@ -480,10 +458,7 @@ Describe "Build-Module" {
         New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
         New-Item -ItemType Directory -Path "TestDrive:/Output/MyModule" -Force
 
-        Mock SetModuleContent -ModuleName ModuleBuilder {}
-        Mock Update-Metadata -ModuleName ModuleBuilder {}
-
-        Mock InitializeBuild -ModuleName ModuleBuilder {
+        Mock InitializeBuild {
             # These are actually all the values that we need
             [PSCustomObject]@{
                 OutputDirectory = "TestDrive:/Output"
@@ -496,27 +471,12 @@ Describe "Build-Module" {
                 PublicFilter    = "Public/*.ps1"
             }
         }
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
-            $Path -eq "TestDrive:/Output/MyModule" -and
-            $ItemType -eq "Directory" -and
-            $Force -eq $true
-        } -ModuleName ModuleBuilder
-        Mock Convert-Path { $Path } -ModuleName ModuleBuilder
-
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:/Output/MyModule" } -ModuleName ModuleBuilder
-
-        Mock Set-Location {} -ModuleName ModuleBuilder
-        Mock Copy-Item {} -ModuleName ModuleBuilder
-        # Release notes
-        Mock Get-Metadata { "First Release" } -ModuleName ModuleBuilder
-        Mock Join-Path {
-            [IO.Path]::Combine($Path, $ChildPath)
-        } -ModuleName ModuleBuilder
+        Mock Convert-Path { $Path }
+        $global:Mock_OutputPath = Convert-FolderSeparator "TestDrive:/Output/MyModule"
 
         Mock Get-ChildItem {
             [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
-        } -ModuleName ModuleBuilder
+        }
 
         try {
             Build-Module @SemVer
@@ -526,17 +486,17 @@ Describe "Build-Module" {
         }
 
         It "Should build to an output folder with the simple version." {
-            Assert-MockCalled Remove-Item -ModuleName ModuleBuilder
-            Assert-MockCalled New-Item -ModuleName ModuleBuilder
+            Assert-MockCalled Remove-Item
+            Assert-MockCalled New-Item
         }
 
         It "Should update the module version to the simple version." {
-            Assert-MockCalled Update-Metadata -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -ParameterFilter {
                 $PropertyName -eq "ModuleVersion" -and $Value -eq $ExpectedVersion
             }
         }
         It "Should not change the module pre-release value" {
-            Assert-MockCalled Update-Metadata -Times 0 -ModuleName ModuleBuilder -ParameterFilter {
+            Assert-MockCalled Update-Metadata -Times 0 -ParameterFilter {
                 $PropertyName -eq "PrivateData.PSData.Prerelease"
             }
         }
@@ -550,10 +510,7 @@ Describe "Build-Module" {
             New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
             New-Item -ItemType Directory -Path "TestDrive:/$ExpectedVersion/" -Force
 
-            Mock SetModuleContent -ModuleName ModuleBuilder { }
-            Mock Update-Metadata -ModuleName ModuleBuilder { }
-
-            Mock InitializeBuild -ModuleName ModuleBuilder {
+            Mock InitializeBuild {
                 # These are actually all the values that we need
                 [PSCustomObject]@{
                     OutputDirectory = "TestDrive:/$Version"
@@ -567,25 +524,11 @@ Describe "Build-Module" {
                 }
             }
 
-            Mock New-Item { [IO.DirectoryInfo]"$TestDrive/$ExpectedVersion" } -Parameter {
-                $Path -eq "TestDrive:/$ExpectedVersion" -and
-                $ItemType -eq "Directory" -and
-                $Force -eq $true
-            } -ModuleName ModuleBuilder
-
-            Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/MyModule/$ExpectedVersion" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-            Mock Remove-Item { } -Parameter { $Path.StartsWith("$TestDrive/$ExpectedVersion") } -ModuleName ModuleBuilder
-            Mock Set-Location { } -ModuleName ModuleBuilder
-            Mock Copy-Item { } -ModuleName ModuleBuilder
-            # Release notes
-            Mock Get-Metadata { "First Release" } -ModuleName ModuleBuilder
-            Mock Join-Path {
-                [IO.Path]::Combine($Path, $ChildPath)
-            } -ModuleName ModuleBuilder
+            $global:Mock_OutputPath = Convert-FolderSeparator "TestDrive:/MyModule/$ExpectedVersion"
 
             Mock Get-ChildItem {
                 [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
-            } -ModuleName ModuleBuilder
+            }
         }
         AfterEach {
             Pop-Location -StackName BuildModuleTest
@@ -597,7 +540,7 @@ Describe "Build-Module" {
                     $PropertyName -eq "PrivateData.PSData.Prerelease"
                 } -MockWith {
                     $Value | Should -Be "pre-release"
-                } -ModuleName ModuleBuilder
+                }
 
                 try {
                     Build-Module -Version "1.2.3" -Prerelease "pre-release"
@@ -607,7 +550,7 @@ Describe "Build-Module" {
 
                 Assert-MockCalled Update-Metadata -ParameterFilter {
                     $PropertyName -eq "PrivateData.PSData.Prerelease" -and $Value -eq "pre-release"
-                } -ModuleName ModuleBuilder
+                }
             }
         }
 
@@ -619,7 +562,7 @@ Describe "Build-Module" {
                     $PropertyName -eq "PrivateData.PSData.Prerelease"
                 } -MockWith {
                     $Value | Should -Be "pre-release"
-                } -ModuleName ModuleBuilder
+                }
 
                 try {
                     Build-Module -SemVer "1.2.3-pre-release"
@@ -629,68 +572,8 @@ Describe "Build-Module" {
 
                 Assert-MockCalled Update-Metadata -ParameterFilter {
                     $PropertyName -eq "PrivateData.PSData.Prerelease" -and $Value -eq "pre-release"
-                } -ModuleName ModuleBuilder
+                }
             }
-        }
-    }
-
-    Context "Does not fall over if you build from the drive root" {
-
-        $null = New-Item "TestDrive:/build.psd1" -Type File -Force -Value "@{}"
-        $null = New-ModuleManifest "TestDrive:/MyModule.psd1" -ModuleVersion "1.0.0" -Author "Tester"
-        $null = New-Item "TestDrive:/Public/Test.ps1" -Type File -Value 'MATCHING TEST CONTENT' -Force
-
-        Mock GetBuildInfo -ModuleName ModuleBuilder {
-            [PSCustomObject]@{
-                SourcePath        = "TestDrive:/MyModule.psd1"
-                Version           = [Version]"1.0.0"
-                Target            = $Target
-                OutputDirectory   = "./output"
-                Encoding          = 'UTF8'
-                SourceDirectories = @('Public')
-            }
-        }
-
-        $Result = Build-Module -SourcePath 'TestDrive:/build.psd1' -OutputDirectory './output' -Passthru -Target Build
-
-        It "Builds the Module in the designated output folder" {
-            $Result.ModuleBase | Should -Be "$TestDrive/Output/MyModule"
-            'TestDrive:/output/MyModule/MyModule.psm1' | Should -FileContentMatch 'MATCHING TEST CONTENT'
-        }
-    }
-
-    Context "Copies additional items specified in CopyPaths" {
-
-        $null = New-Item "TestDrive:/build.psd1" -Type File -Force -Value "@{}"
-        $null = New-ModuleManifest "TestDrive:/MyModule.psd1" -ModuleVersion "1.0.0" -Author "Tester"
-        $null = New-Item "TestDrive:/Public/Test.ps1" -Type File -Value 'MATCHING TEST CONTENT' -Force
-        $null = New-Item "TestDrive:/MyModule.format.ps1xml" -Type File -Value '<Configuration />' -Force
-        $null = New-Item "TestDrive:/lib/imaginary1.dll" -Type File -Value '1' -Force
-        $null = New-Item "TestDrive:/lib/subdir/imaginary2.dll" -Type File -Value '2' -Force
-
-        Mock GetBuildInfo -ModuleName ModuleBuilder {
-            [PSCustomObject]@{
-                SourcePath        = "TestDrive:/MyModule.psd1"
-                Version           = [Version]"1.0.0"
-                Target            = $Target
-                OutputDirectory   = "./output"
-                CopyPaths         = "./lib", "./MyModule.format.ps1xml"
-                Encoding          = 'UTF8'
-                SourceDirectories = @('Public')
-            }
-        }
-
-        $Result = Build-Module -SourcePath 'TestDrive:/build.psd1' -OutputDirectory './output' -Passthru -Target Build
-
-        It "Copies single files that are in CopyPaths" {
-            $Result.ModuleBase | Should -Be "$TestDrive/output/MyModule"
-            'TestDrive:/output/MyModule/MyModule.format.ps1xml' | Should -Exist
-            'TestDrive:/output/MyModule/MyModule.format.ps1xml' | Should -FileContentMatch '<Configuration />'
-        }
-
-        It "Recursively copies all the files in folders that are in CopyPaths" {
-            'TestDrive:/output/MyModule/lib/imaginary1.dll' | Should -FileContentMatch '1'
-            'TestDrive:/output/MyModule/lib/subdir/imaginary2.dll' | Should -FileContentMatch '2'
         }
     }
 }

--- a/Tests/Public/Build-Module.Tests.ps1
+++ b/Tests/Public/Build-Module.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Build-Module" {
             $parameters["SourcePath"].Attributes.Where{$_ -is [Parameter]}.Mandatory | Should -Be $false
         }
         It "throws if the SourcePath doesn't exist" {
-            { Build-Module -SourcePath TestDrive:\NoSuchPath } | Should -Throw "Source must point to a valid module"
+            { Build-Module -SourcePath TestDrive:/NoSuchPath } | Should -Throw "Source must point to a valid module"
         }
 
         It "has an optional string parameter for the OutputDirectory" {
@@ -74,8 +74,8 @@ Describe "Build-Module" {
     }
 
     Context "When run without parameters" {
-        Push-Location TestDrive:\ -StackName BuildModuleTest
-        New-Item -ItemType Directory -Path TestDrive:\Output\MyModule\1.0.0\ -Force
+        Push-Location TestDrive:/ -StackName BuildModuleTest
+        New-Item -ItemType Directory -Path TestDrive:/Output/MyModule/1.0.0/ -Force
 
         Mock SetModuleContent -ModuleName ModuleBuilder {}
         Mock ConvertToAst -ModuleName ModuleBuilder {
@@ -92,30 +92,30 @@ Describe "Build-Module" {
         Mock InitializeBuild -ModuleName ModuleBuilder {
             # These are actually all the values that we need
             [PSCustomObject]@{
-                OutputDirectory = "TestDrive:\Output"
+                OutputDirectory = "TestDrive:/Output"
                 Name            = "MyModule"
                 Version         = [Version]"1.0.0"
                 Target          = "CleanBuild"
-                ModuleBase      = "TestDrive:\MyModule\"
+                ModuleBase      = "TestDrive:/MyModule/"
                 CopyDirectories = @()
                 Encoding        = "UTF8"
-                PublicFilter    = "Public\*.ps1"
+                PublicFilter    = "Public/*.ps1"
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive\Output\MyModule") } -Parameter {
-            $Path -eq "TestDrive:\Output\MyModule" -and
+        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
+            $Path -eq "TestDrive:/Output/MyModule" -and
             $ItemType -eq "Directory" -and
             $Force -eq $true
         } -ModuleName ModuleBuilder
 
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:\Output\MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:\Output\MyModule" } -ModuleName ModuleBuilder
+        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
+        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:/Output/MyModule" } -ModuleName ModuleBuilder
         Mock Push-Location {} -ModuleName ModuleBuilder
         Mock Copy-Item {} -ModuleName ModuleBuilder
 
         Mock Get-ChildItem {
-            [IO.FileInfo]"$TestDrive\Output\MyModule\Public\Get-MyInfo.ps1"
+            [IO.FileInfo]"$TestDrive/Output/MyModule/Public/Get-MyInfo.ps1"
         } -ModuleName ModuleBuilder
 
 
@@ -136,7 +136,7 @@ Describe "Build-Module" {
 
         It "Should run in the module source folder" {
             Assert-MockCalled Push-Location -ModuleName ModuleBuilder -Parameter {
-                $Path -eq "TestDrive:\MyModule\"
+                $Path -eq "TestDrive:/MyModule/"
             }
         }
 
@@ -168,43 +168,43 @@ Describe "Build-Module" {
     }
 
     Context "When run without 'Clean' in the target" {
-        Push-Location TestDrive:\ -StackName BuildModuleTest
-        New-Item -ItemType Directory -Path TestDrive:\MyModule\Public -Force
-        New-Item -ItemType File -Path TestDrive:\MyModule\Public\Get-MyInfo.ps1 -Force
+        Push-Location TestDrive:/ -StackName BuildModuleTest
+        New-Item -ItemType Directory -Path TestDrive:/MyModule/Public -Force
+        New-Item -ItemType File -Path TestDrive:/MyModule/Public/Get-MyInfo.ps1 -Force
         Start-Sleep -Milliseconds 200 # to ensure the output is after the input
-        New-Item -ItemType Directory -Path TestDrive:\1.0.0\ -Force
-        New-Item -ItemType File -Path TestDrive:\1.0.0\MyModule.psm1 -Force
+        New-Item -ItemType Directory -Path TestDrive:/1.0.0/ -Force
+        New-Item -ItemType File -Path TestDrive:/1.0.0/MyModule.psm1 -Force
 
         Mock SetModuleContent -ModuleName ModuleBuilder {}
         Mock Update-Metadata -ModuleName ModuleBuilder {}
         Mock InitializeBuild -ModuleName ModuleBuilder {
             # These are actually all the values that we need
             [PSCustomObject]@{
-                OutputDirectory = "TestDrive:\Output"
+                OutputDirectory = "TestDrive:/Output"
                 Name            = "MyModule"
                 Version         = [Version]"1.0.0"
                 Target          = $Target
-                ModuleBase      = "TestDrive:\MyModule\"
+                ModuleBase      = "TestDrive:/MyModule/"
                 CopyDirectories = @()
                 Encoding        = "UTF8"
-                PublicFilter    = "Public\*.ps1"
+                PublicFilter    = "Public/*.ps1"
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive\Output\MyModule") } -Parameter {
-            $Path -eq "TestDrive:\Output\MyModule" -and
+        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
+            $Path -eq "TestDrive:/Output/MyModule" -and
             $ItemType -eq "Directory" -and
             $Force -eq $true
         } -ModuleName ModuleBuilder
         Mock Convert-Path { $Path } -ModuleName ModuleBuilder
 
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:\Output\MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:\Output\MyModule" } -ModuleName ModuleBuilder
+        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
+        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:/Output/MyModule" } -ModuleName ModuleBuilder
         Mock Set-Location {} -ModuleName ModuleBuilder
         Mock Copy-Item {} -ModuleName ModuleBuilder
 
         Mock Get-ChildItem {
-            [IO.FileInfo]"$TestDrive\MyModule\Public\Get-MyInfo.ps1"
+            [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
         } -ModuleName ModuleBuilder
 
         Mock Get-Item {
@@ -238,9 +238,9 @@ Describe "Build-Module" {
     Context "Setting the version to a SemVer string" {
         $SemVer = "1.0.0-beta03+sha.22c35ffff166f34addc49a3b80e622b543199cc5.Date.2018-10-11"
         $global:ExpectedVersion = "1.0.0"
-        Push-Location TestDrive:\ -StackName BuildModuleTest
-        New-Item -ItemType Directory -Path TestDrive:\MyModule\ -Force
-        New-Item -ItemType Directory -Path "TestDrive:\Output\MyModule\$ExpectedVersion" -Force
+        Push-Location TestDrive:/ -StackName BuildModuleTest
+        New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
+        New-Item -ItemType Directory -Path "TestDrive:/Output/MyModule/$ExpectedVersion" -Force
 
         Mock SetModuleContent -ModuleName ModuleBuilder {}
         Mock Update-Metadata -ModuleName ModuleBuilder {}
@@ -248,27 +248,27 @@ Describe "Build-Module" {
         Mock InitializeBuild -ModuleName ModuleBuilder {
             # These are actually all the values that we need
             [PSCustomObject]@{
-                OutputDirectory = "TestDrive:\Output"
+                OutputDirectory = "TestDrive:/Output"
                 Name            = "MyModule"
                 Version         = $Version
                 Target          = $Target
-                ModuleBase      = "TestDrive:\MyModule\"
+                ModuleBase      = "TestDrive:/MyModule/"
                 CopyPaths = @()
                 Encoding        = "UTF8"
-                PublicFilter    = "Public\*.ps1"
+                PublicFilter    = "Public/*.ps1"
                 VersionedOutputDirectory = $true
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive\Output\MyModule\$ExpectedVersion") } -Parameter {
-            $Path -eq "TestDrive:\Output\MyModule\$ExpectedVersion" -and
+        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule/$ExpectedVersion") } -Parameter {
+            $Path -eq "TestDrive:/Output/MyModule/$ExpectedVersion" -and
             $ItemType -eq "Directory" -and
             $Force -eq $true
         } -ModuleName ModuleBuilder
 
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:\Output\MyModule\$ExpectedVersion" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
+        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule/$ExpectedVersion" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
         Mock Remove-Item {} -Parameter {
-            $Path -eq "TestDrive:\Output\MyModule\1.0.0"
+            $Path -eq "TestDrive:/Output/MyModule/1.0.0"
         } -ModuleName ModuleBuilder
         Mock Set-Location {} -ModuleName ModuleBuilder
         Mock Copy-Item {} -ModuleName ModuleBuilder
@@ -279,7 +279,7 @@ Describe "Build-Module" {
         } -ModuleName ModuleBuilder
 
         Mock Get-ChildItem {
-            [IO.FileInfo]"$TestDrive\MyModule\Public\Get-MyInfo.ps1"
+            [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
         } -ModuleName ModuleBuilder
 
         try {
@@ -358,9 +358,9 @@ Describe "Build-Module" {
             BuildMetadata = "Sha.22c35ffff166f34addc49a3b80e622b543199cc5.Date.2018-10-11"
         }
         $global:ExpectedVersion = "1.0.0"
-        Push-Location TestDrive:\ -StackName BuildModuleTest
-        New-Item -ItemType Directory -Path TestDrive:\MyModule\ -Force
-        New-Item -ItemType Directory -Path "TestDrive:\Output\MyModule\$ExpectedVersion" -Force
+        Push-Location TestDrive:/ -StackName BuildModuleTest
+        New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
+        New-Item -ItemType Directory -Path "TestDrive:/Output/MyModule/$ExpectedVersion" -Force
 
         Mock SetModuleContent -ModuleName ModuleBuilder {}
         Mock Update-Metadata -ModuleName ModuleBuilder {}
@@ -368,25 +368,25 @@ Describe "Build-Module" {
         Mock InitializeBuild -ModuleName ModuleBuilder {
             # These are actually all the values that we need
             [PSCustomObject]@{
-                OutputDirectory = "TestDrive:\Output"
+                OutputDirectory = "TestDrive:/Output"
                 Name            = "MyModule"
                 Version         = $Version
                 Target          = $Target
-                ModuleBase      = "TestDrive:\MyModule\"
+                ModuleBase      = "TestDrive:/MyModule/"
                 CopyPaths = @()
                 Encoding        = "UTF8"
-                PublicFilter    = "Public\*.ps1"
+                PublicFilter    = "Public/*.ps1"
             }
         }
 
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive\Output\MyModule") } -Parameter {
-            $Path -eq "TestDrive:\Output\MyModule" -and
+        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
+            $Path -eq "TestDrive:/Output/MyModule" -and
             $ItemType -eq "Directory" -and
             $Force -eq $true
         } -ModuleName ModuleBuilder
 
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:\Output\MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter {$Path -eq "TestDrive:\Output\MyModule"} -ModuleName ModuleBuilder
+        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
+        Mock Remove-Item {} -Parameter {$Path -eq "TestDrive:/Output/MyModule"} -ModuleName ModuleBuilder
         Mock Set-Location {} -ModuleName ModuleBuilder
         Mock Copy-Item {} -ModuleName ModuleBuilder
         # Release notes
@@ -396,7 +396,7 @@ Describe "Build-Module" {
         } -ModuleName ModuleBuilder
 
         Mock Get-ChildItem {
-            [IO.FileInfo]"$TestDrive\MyModule\Public\Get-MyInfo.ps1"
+            [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
         } -ModuleName ModuleBuilder
 
         try {
@@ -476,9 +476,9 @@ Describe "Build-Module" {
             BuildMetadata = "Sha.22c35ffff166f34addc49a3b80e622b543199cc5.Date.2018-10-11"
         }
         $global:ExpectedVersion = "1.0.0"
-        Push-Location TestDrive:\ -StackName BuildModuleTest
-        New-Item -ItemType Directory -Path TestDrive:\MyModule\ -Force
-        New-Item -ItemType Directory -Path "TestDrive:\Output\MyModule" -Force
+        Push-Location TestDrive:/ -StackName BuildModuleTest
+        New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
+        New-Item -ItemType Directory -Path "TestDrive:/Output/MyModule" -Force
 
         Mock SetModuleContent -ModuleName ModuleBuilder {}
         Mock Update-Metadata -ModuleName ModuleBuilder {}
@@ -486,25 +486,25 @@ Describe "Build-Module" {
         Mock InitializeBuild -ModuleName ModuleBuilder {
             # These are actually all the values that we need
             [PSCustomObject]@{
-                OutputDirectory = "TestDrive:\Output"
+                OutputDirectory = "TestDrive:/Output"
                 Name            = "MyModule"
                 Version         = [Version]"1.0.0"
                 Target          = $Target
-                ModuleBase      = "TestDrive:\MyModule\"
+                ModuleBase      = "TestDrive:/MyModule/"
                 CopyPaths       = @()
                 Encoding        = "UTF8"
-                PublicFilter    = "Public\*.ps1"
+                PublicFilter    = "Public/*.ps1"
             }
         }
-        Mock New-Item { [IO.DirectoryInfo]("$TestDrive\Output\MyModule") } -Parameter {
-            $Path -eq "TestDrive:\Output\MyModule" -and
+        Mock New-Item { [IO.DirectoryInfo]("$TestDrive/Output/MyModule") } -Parameter {
+            $Path -eq "TestDrive:/Output/MyModule" -and
             $ItemType -eq "Directory" -and
             $Force -eq $true
         } -ModuleName ModuleBuilder
         Mock Convert-Path { $Path } -ModuleName ModuleBuilder
 
-        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:\Output\MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:\Output\MyModule" } -ModuleName ModuleBuilder
+        Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/Output/MyModule" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
+        Mock Remove-Item {} -Parameter { $Path -eq "TestDrive:/Output/MyModule" } -ModuleName ModuleBuilder
 
         Mock Set-Location {} -ModuleName ModuleBuilder
         Mock Copy-Item {} -ModuleName ModuleBuilder
@@ -515,7 +515,7 @@ Describe "Build-Module" {
         } -ModuleName ModuleBuilder
 
         Mock Get-ChildItem {
-            [IO.FileInfo]"$TestDrive\MyModule\Public\Get-MyInfo.ps1"
+            [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
         } -ModuleName ModuleBuilder
 
         try {
@@ -546,9 +546,9 @@ Describe "Build-Module" {
 
     Context "Bug #70 Cannot build 1.2.3-pre-release" {
         BeforeEach {
-            Push-Location TestDrive:\ -StackName BuildModuleTest
-            New-Item -ItemType Directory -Path TestDrive:\MyModule\ -Force
-            New-Item -ItemType Directory -Path "TestDrive:\$ExpectedVersion\" -Force
+            Push-Location TestDrive:/ -StackName BuildModuleTest
+            New-Item -ItemType Directory -Path TestDrive:/MyModule/ -Force
+            New-Item -ItemType Directory -Path "TestDrive:/$ExpectedVersion/" -Force
 
             Mock SetModuleContent -ModuleName ModuleBuilder { }
             Mock Update-Metadata -ModuleName ModuleBuilder { }
@@ -556,25 +556,25 @@ Describe "Build-Module" {
             Mock InitializeBuild -ModuleName ModuleBuilder {
                 # These are actually all the values that we need
                 [PSCustomObject]@{
-                    OutputDirectory = "TestDrive:\$Version"
+                    OutputDirectory = "TestDrive:/$Version"
                     Name            = "MyModule"
                     Version         = $Version
                     Target          = $Target
-                    ModuleBase      = "TestDrive:\MyModule\"
+                    ModuleBase      = "TestDrive:/MyModule/"
                     CopyPaths = @()
                     Encoding        = "UTF8"
-                    PublicFilter    = "Public\*.ps1"
+                    PublicFilter    = "Public/*.ps1"
                 }
             }
 
-            Mock New-Item { [IO.DirectoryInfo]"$TestDrive\$ExpectedVersion" } -Parameter {
-                $Path -eq "TestDrive:\$ExpectedVersion" -and
+            Mock New-Item { [IO.DirectoryInfo]"$TestDrive/$ExpectedVersion" } -Parameter {
+                $Path -eq "TestDrive:/$ExpectedVersion" -and
                 $ItemType -eq "Directory" -and
                 $Force -eq $true
             } -ModuleName ModuleBuilder
 
-            Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:\MyModule\$ExpectedVersion" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
-            Mock Remove-Item { } -Parameter { $Path.StartsWith("$TestDrive\$ExpectedVersion") } -ModuleName ModuleBuilder
+            Mock Test-Path { $True } -Parameter { $Path -eq "TestDrive:/MyModule/$ExpectedVersion" -and ($PathType -notin "Any", "Leaf") } -ModuleName ModuleBuilder
+            Mock Remove-Item { } -Parameter { $Path.StartsWith("$TestDrive/$ExpectedVersion") } -ModuleName ModuleBuilder
             Mock Set-Location { } -ModuleName ModuleBuilder
             Mock Copy-Item { } -ModuleName ModuleBuilder
             # Release notes
@@ -584,7 +584,7 @@ Describe "Build-Module" {
             } -ModuleName ModuleBuilder
 
             Mock Get-ChildItem {
-                [IO.FileInfo]"$TestDrive\MyModule\Public\Get-MyInfo.ps1"
+                [IO.FileInfo]"$TestDrive/MyModule/Public/Get-MyInfo.ps1"
             } -ModuleName ModuleBuilder
         }
         AfterEach {
@@ -636,13 +636,13 @@ Describe "Build-Module" {
 
     Context "Does not fall over if you build from the drive root" {
 
-        $null = New-Item "TestDrive:\build.psd1" -Type File -Force -Value "@{}"
-        $null = New-ModuleManifest "TestDrive:\MyModule.psd1" -ModuleVersion "1.0.0" -Author "Tester"
-        $null = New-Item "TestDrive:\Public\Test.ps1" -Type File -Value 'MATCHING TEST CONTENT' -Force
+        $null = New-Item "TestDrive:/build.psd1" -Type File -Force -Value "@{}"
+        $null = New-ModuleManifest "TestDrive:/MyModule.psd1" -ModuleVersion "1.0.0" -Author "Tester"
+        $null = New-Item "TestDrive:/Public/Test.ps1" -Type File -Value 'MATCHING TEST CONTENT' -Force
 
         Mock GetBuildInfo -ModuleName ModuleBuilder {
             [PSCustomObject]@{
-                SourcePath        = "TestDrive:\MyModule.psd1"
+                SourcePath        = "TestDrive:/MyModule.psd1"
                 Version           = [Version]"1.0.0"
                 Target            = $Target
                 OutputDirectory   = "./output"
@@ -651,26 +651,26 @@ Describe "Build-Module" {
             }
         }
 
-        $Result = Build-Module -SourcePath 'TestDrive:\build.psd1' -OutputDirectory '.\output' -Passthru -Target Build
+        $Result = Build-Module -SourcePath 'TestDrive:/build.psd1' -OutputDirectory './output' -Passthru -Target Build
 
         It "Builds the Module in the designated output folder" {
-            $Result.ModuleBase | Should -Be ("TestDrive:\output\MyModule" | Convert-Path).TrimEnd('\')
-            'TestDrive:\output\MyModule\MyModule.psm1' | Should -FileContentMatch 'MATCHING TEST CONTENT'
+            $Result.ModuleBase | Should -Be "$TestDrive/Output/MyModule"
+            'TestDrive:/output/MyModule/MyModule.psm1' | Should -FileContentMatch 'MATCHING TEST CONTENT'
         }
     }
 
     Context "Copies additional items specified in CopyPaths" {
 
-        $null = New-Item "TestDrive:\build.psd1" -Type File -Force -Value "@{}"
-        $null = New-ModuleManifest "TestDrive:\MyModule.psd1" -ModuleVersion "1.0.0" -Author "Tester"
-        $null = New-Item "TestDrive:\Public\Test.ps1" -Type File -Value 'MATCHING TEST CONTENT' -Force
-        $null = New-Item "TestDrive:\MyModule.format.ps1xml" -Type File -Value '<Configuration />' -Force
-        $null = New-Item "TestDrive:\lib\imaginary1.dll" -Type File -Value '1' -Force
-        $null = New-Item "TestDrive:\lib\subdir\imaginary2.dll" -Type File -Value '2' -Force
+        $null = New-Item "TestDrive:/build.psd1" -Type File -Force -Value "@{}"
+        $null = New-ModuleManifest "TestDrive:/MyModule.psd1" -ModuleVersion "1.0.0" -Author "Tester"
+        $null = New-Item "TestDrive:/Public/Test.ps1" -Type File -Value 'MATCHING TEST CONTENT' -Force
+        $null = New-Item "TestDrive:/MyModule.format.ps1xml" -Type File -Value '<Configuration />' -Force
+        $null = New-Item "TestDrive:/lib/imaginary1.dll" -Type File -Value '1' -Force
+        $null = New-Item "TestDrive:/lib/subdir/imaginary2.dll" -Type File -Value '2' -Force
 
         Mock GetBuildInfo -ModuleName ModuleBuilder {
             [PSCustomObject]@{
-                SourcePath        = "TestDrive:\MyModule.psd1"
+                SourcePath        = "TestDrive:/MyModule.psd1"
                 Version           = [Version]"1.0.0"
                 Target            = $Target
                 OutputDirectory   = "./output"
@@ -680,17 +680,17 @@ Describe "Build-Module" {
             }
         }
 
-        $Result = Build-Module -SourcePath 'TestDrive:\build.psd1' -OutputDirectory '.\output' -Passthru -Target Build
+        $Result = Build-Module -SourcePath 'TestDrive:/build.psd1' -OutputDirectory './output' -Passthru -Target Build
 
         It "Copies single files that are in CopyPaths" {
-            $Result.ModuleBase | Should -Be ("TestDrive:\output\MyModule" | Convert-Path).TrimEnd('\')
-            'TestDrive:\output\MyModule\MyModule.format.ps1xml' | Should -Exist
-            'TestDrive:\output\MyModule\MyModule.format.ps1xml' | Should -FileContentMatch '<Configuration />'
+            $Result.ModuleBase | Should -Be "$TestDrive/output/MyModule"
+            'TestDrive:/output/MyModule/MyModule.format.ps1xml' | Should -Exist
+            'TestDrive:/output/MyModule/MyModule.format.ps1xml' | Should -FileContentMatch '<Configuration />'
         }
 
         It "Recursively copies all the files in folders that are in CopyPaths" {
-            'TestDrive:\output\MyModule\lib\imaginary1.dll' | Should -FileContentMatch '1'
-            'TestDrive:\output\MyModule\lib\subdir\imaginary2.dll' | Should -FileContentMatch '2'
+            'TestDrive:/output/MyModule/lib/imaginary1.dll' | Should -FileContentMatch '1'
+            'TestDrive:/output/MyModule/lib/subdir/imaginary2.dll' | Should -FileContentMatch '2'
         }
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -38,7 +38,7 @@ try {
     # Build new output
     $ParameterString = $PSBoundParameters.GetEnumerator().ForEach{ '-' + $_.Key + " '" + $_.Value + "'" } -join " "
     Write-Verbose "Build-Module Source\build.psd1 $($ParameterString) -Target CleanBuild"
-    ModuleBuilderBootstrap\Build-Module Source\build.psd1 @PSBoundParameters -Target CleanBuild -Passthru -OutVariable BuildOutput | Split-Path
+    ModuleBuilderBootstrap\Build-Module -SourcePath Source\build.psd1 @PSBoundParameters -Target CleanBuild -Passthru -OutVariable BuildOutput | Split-Path
     Write-Verbose "Module build output in $(Split-Path $BuildOutput.Path)"
 
     # Clean up environment

--- a/test.ps1
+++ b/test.ps1
@@ -36,7 +36,7 @@ if (-not $SkipCodeCoverage) {
     Invoke-Pester ./Tests -Show $Show -PesterOption @{
         IncludeVSCodeMarker = $IncludeVSCodeMarker
     } -CodeCoverage $ModuleUnderTest.Path -CodeCoverageOutputFile ./coverage.xml -PassThru |
-        Convert-CodeCoverage -SourceRoot ./Source -Relative
+        Convert-CodeCoverage -SourceRoot ./Source
 } else {
     Invoke-Pester ./Tests -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
 }

--- a/test.ps1
+++ b/test.ps1
@@ -1,6 +1,7 @@
 #requires -Module PowerShellGet, Pester
 using namespace Microsoft.PackageManagement.Provider.Utility
 param(
+    [switch]$SkipScriptAnalyzer,
     [switch]$SkipCodeCoverage,
     [switch]$HideSuccess,
     [switch]$IncludeVSCodeMarker
@@ -41,6 +42,10 @@ if (-not $SkipCodeCoverage) {
     Invoke-Pester ./Tests -Show $Show -PesterOption @{ IncludeVSCodeMarker = $IncludeVSCodeMarker }
 }
 
+Write-Host
+if (-not $SkipScriptAnalyzer) {
+    Invoke-ScriptAnalyzer $ModuleUnderTest.Path
+}
 Pop-Location
 
 # Re-enable default parameters after testing


### PR DESCRIPTION
A bunch of minor changes:
- Fixes #76 by updating the documentation
- Fixes #39 by adding documentation
- Fixes #99 by putting back the helpful Install-RequiredModule wrapper
- Fixes #30 so -Passthru works when the build is skipped
- Fixes #93 to only change PreRelease if -Semver or -Prerelease are explicitly passed

