### PR TITLE
Fix BinarySearch type issue in ConvertTo-SourceLineNumber

### DIFF
--- a/Source/Public/ConvertTo-SourceLineNumber.ps1
+++ b/Source/Public/ConvertTo-SourceLineNumber.ps1
@@ -72,7 +72,7 @@ function ConvertTo-SourceLineNumber {
             # These are all negative, because BinarySearch returns the match *after* the line we're searching for
             # We need the match *before* the line we're searching for
             # And we need it as a zero-based index:
-            $index = -2 - [Array]::BinarySearch($hit.StartLineNumber, $SourceLineNumber )
+            $index = -2 - [Array]::BinarySearch($hit.StartLineNumber, $SourceLineNumber)
             $Source = $hit[$index]
 
             if($Passthru) {

--- a/Source/Public/ConvertTo-SourceLineNumber.ps1
+++ b/Source/Public/ConvertTo-SourceLineNumber.ps1
@@ -72,7 +72,6 @@ function ConvertTo-SourceLineNumber {
             # These are all negative, because BinarySearch returns the match *after* the line we're searching for
             # We need the match *before* the line we're searching for
             # And we need it as a zero-based index:
-            # Cast $SourceLineNumber to the type of the first item in $hit.StartLineNumber
             $index = -2 - [Array]::BinarySearch($hit.StartLineNumber, $SourceLineNumber )
             $Source = $hit[$index]
 

--- a/Source/Public/ConvertTo-SourceLineNumber.ps1
+++ b/Source/Public/ConvertTo-SourceLineNumber.ps1
@@ -22,7 +22,7 @@ function ConvertTo-SourceLineNumber {
         # The SourceLineNumber (from an InvocationInfo) is the module line number
         [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position=1, ParameterSetName="FromInvocationInfo")]
         [Alias("LineNumber", "Line", "ScriptLineNumber")]
-        [Int]$SourceLineNumber,
+        [int]$SourceLineNumber,
 
         # The actual InvocationInfo
         [Parameter(ValueFromPipeline, DontShow, ParameterSetName="FromInvocationInfo")]

--- a/Source/Public/ConvertTo-SourceLineNumber.ps1
+++ b/Source/Public/ConvertTo-SourceLineNumber.ps1
@@ -22,7 +22,7 @@ function ConvertTo-SourceLineNumber {
         # The SourceLineNumber (from an InvocationInfo) is the module line number
         [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position=1, ParameterSetName="FromInvocationInfo")]
         [Alias("LineNumber", "Line", "ScriptLineNumber")]
-        [int]$SourceLineNumber,
+        $SourceLineNumber,
 
         # The actual InvocationInfo
         [Parameter(ValueFromPipeline, DontShow, ParameterSetName="FromInvocationInfo")]
@@ -72,7 +72,8 @@ function ConvertTo-SourceLineNumber {
             # These are all negative, because BinarySearch returns the match *after* the line we're searching for
             # We need the match *before* the line we're searching for
             # And we need it as a zero-based index:
-            $index = -2 - [Array]::BinarySearch($hit.StartLineNumber, $SourceLineNumber)
+            # Cast $SourceLineNumber to the type of the first item in $hit.StartLineNumber
+            $index = -2 - [Array]::BinarySearch($hit.StartLineNumber, $($SourceLineNumber -as $hit.StartLineNumber[0].GetType()) )
             $Source = $hit[$index]
 
             if($Passthru) {

--- a/Source/Public/ConvertTo-SourceLineNumber.ps1
+++ b/Source/Public/ConvertTo-SourceLineNumber.ps1
@@ -22,7 +22,7 @@ function ConvertTo-SourceLineNumber {
         # The SourceLineNumber (from an InvocationInfo) is the module line number
         [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position=1, ParameterSetName="FromInvocationInfo")]
         [Alias("LineNumber", "Line", "ScriptLineNumber")]
-        $SourceLineNumber,
+        [Int]$SourceLineNumber,
 
         # The actual InvocationInfo
         [Parameter(ValueFromPipeline, DontShow, ParameterSetName="FromInvocationInfo")]

--- a/Source/Public/ConvertTo-SourceLineNumber.ps1
+++ b/Source/Public/ConvertTo-SourceLineNumber.ps1
@@ -58,7 +58,7 @@ function ConvertTo-SourceLineNumber {
                         [PSCustomObject]@{
                             PSTypeName = "BuildSourceMapping"
                             SourceFile = $_.Matches[0].Groups["SourceFile"].Value.Trim("'")
-                            StartLineNumber = $_.LineNumber
+                            StartLineNumber = [System.Int32] $_.LineNumber
                             # This offset is added when calculating the line number
                             # because of the new line we're adding prior to the content
                             # of each script file in the built module.
@@ -73,7 +73,7 @@ function ConvertTo-SourceLineNumber {
             # We need the match *before* the line we're searching for
             # And we need it as a zero-based index:
             # Cast $SourceLineNumber to the type of the first item in $hit.StartLineNumber
-            $index = -2 - [Array]::BinarySearch($hit.StartLineNumber, $($SourceLineNumber -as $hit.StartLineNumber[0].GetType()) )
+            $index = -2 - [Array]::BinarySearch($hit.StartLineNumber, $SourceLineNumber )
             $Source = $hit[$index]
 
             if($Passthru) {

--- a/Tests/Public/ConvertTo-SourceLineNumber.Tests.ps1
+++ b/Tests/Public/ConvertTo-SourceLineNumber.Tests.ps1
@@ -20,7 +20,6 @@ Describe "ConvertTo-SourceLineNumber" {
         Pop-Location -StackName ConvertTo-SourceLineNumber
     }
 
-
     It "Should map line <outputLine> in the Module to line <sourceLine> in the source of <sourceFile>" -TestCases $TestCases {
         param($outputLine, $sourceFile, $sourceLine)
 
@@ -78,5 +77,15 @@ Describe "ConvertTo-SourceLineNumber" {
         $SourceLocation.SourceFile | Should -Be ".${\}Public${\}Get-Source.ps1"
         $SourceLocation.SourceLineNumber | Should -Be 5
         $SourceLocation.Function | Should -Be 'Get-Source'
+    }
+
+    It 'Should handle type differences correctly' {
+        $SourceLocation = ConvertTo-SourceLineNumber -SourceFile $Convert_LineNumber_ModulePath -SourceLineNumber [System.UInt64]48
+        $SourceLocation.SourceFile | Should -Be ".${\}Public${\}Get-Source.ps1"
+        $SourceLocation.SourceLineNumber | Should -Be 5
+
+        $SourceLocation = ConvertTo-SourceLineNumber -SourceFile $Convert_LineNumber_ModulePath -SourceLineNumber [System.Int32]48
+        $SourceLocation.SourceFile | Should -Be ".${\}Public${\}Get-Source.ps1"
+        $SourceLocation.SourceLineNumber | Should -Be 5
     }
 }

--- a/Tests/Public/ConvertTo-SourceLineNumber.Tests.ps1
+++ b/Tests/Public/ConvertTo-SourceLineNumber.Tests.ps1
@@ -80,11 +80,11 @@ Describe "ConvertTo-SourceLineNumber" {
     }
 
     It 'Should handle type differences correctly' {
-        $SourceLocation = ConvertTo-SourceLineNumber -SourceFile $Convert_LineNumber_ModulePath -SourceLineNumber [System.UInt64]48
+        $SourceLocation = ConvertTo-SourceLineNumber -SourceFile $Convert_LineNumber_ModulePath -SourceLineNumber ([System.UInt64]48)
         $SourceLocation.SourceFile | Should -Be ".${\}Public${\}Get-Source.ps1"
         $SourceLocation.SourceLineNumber | Should -Be 5
 
-        $SourceLocation = ConvertTo-SourceLineNumber -SourceFile $Convert_LineNumber_ModulePath -SourceLineNumber [System.Int32]48
+        $SourceLocation = ConvertTo-SourceLineNumber -SourceFile $Convert_LineNumber_ModulePath -SourceLineNumber ([System.Int32]48)
         $SourceLocation.SourceFile | Should -Be ".${\}Public${\}Get-Source.ps1"
         $SourceLocation.SourceLineNumber | Should -Be 5
     }


### PR DESCRIPTION
Fixes #131

This type issue was introduced since Pwsh 7.5.0 is based on .Net 9.
This solution is to type cast the variable and align it to be the same type.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PoshCode/ModuleBuilder/pull/132?shareId=e7135060-591f-4796-a516-407aedf02f04).