### PR TITLE
Fix parse error in Windows PowerShell

### DIFF
--- a/Source/Private/InitializeBuild.ps1
+++ b/Source/Private/InitializeBuild.ps1
@@ -37,11 +37,11 @@ function InitializeBuild {
     if ($BuildInfo.SemVer) {
         Write-Verbose "Update the Version, Prerelease, and BuildMetadata from the SemVer (in case it was passed in via build.psd1)"
         $BuildInfo = $BuildInfo | Update-Object @{
-            Version       = if (($V = $BuildInfo.SemVer.Split("+")[0].Split("-", 2)[0])) {
-                                [version]$V
-                            }
             Prerelease    = $BuildInfo.SemVer.Split("+")[0].Split("-", 2)[1]
             BuildMetadata = $BuildInfo.SemVer.Split("+", 2)[1]
+            Version       = if (($V = $BuildInfo.SemVer.Split("+")[0].Split("-", 2)[0])) {
+                [version]$V
+            }
         }
     } elseif($BuildInfo.Version) {
         Write-Verbose "Calculate the Semantic Version from the Version - Prerelease + BuildMetadata"


### PR DESCRIPTION
This will fix issue #135.

In Windows PowerShell this will not work:

```powershell
@{
    Version       = if (($V = $BuildInfo.SemVer.Split("+")[0].Split("-", 2)[0])) {
                        [version]$V
                    }
    Prerelease    = $BuildInfo.SemVer.Split("+")[0].Split("-", 2)[1]
    BuildMetadata = $BuildInfo.SemVer.Split("+", 2)[1]
}
```
but this will:

```powershell
@{
    Prerelease    = $BuildInfo.SemVer.Split("+")[0].Split("-", 2)[1]
    BuildMetadata = $BuildInfo.SemVer.Split("+", 2)[1]
    Version       = if (($V = $BuildInfo.SemVer.Split("+")[0].Split("-", 2)[0])) {
                        [version]$V
                    }
}
```

By moving the Version property at the end there is no parse error. 

This error does not occur on PowerShell 7.x. It handles if-blocks in hashtables better apparently. 