### PR TITLE
fixing #140 where code is incompatible with Windows PowerShell

### DIFF
--- a/Source/Public/Add-Parameter.ps1
+++ b/Source/Public/Add-Parameter.ps1
@@ -194,7 +194,7 @@ function Add-Parameter {
         }
     }
     process {
-        Write-Debug "Add-Parameter $($InputObject.Extent.File -ne "scriptblock" ? $InputObject.Extent.File : ( "L:" + $InputObject.Extent.StartLineNumber + ".." + $InputObject.Extent.EndLineNumber + " C:" + $InputObject.Extent.StartColumnNumber + ".." + $InputObject.Extent.EndColumnNumber)) $FunctionName $Boilerplate"
+        Write-Debug "Add-Parameter $(if ($InputObject.Extent.File -ne "scriptblock") { $InputObject.Extent.File } else { "L:" + $InputObject.Extent.StartLineNumber + ".." + $InputObject.Extent.EndLineNumber + " C:" + $InputObject.Extent.StartColumnNumber + ".." + $InputObject.Extent.EndColumnNumber }) $FunctionName $Boilerplate"
 
         $Generator = [ParameterGenerator]@{
             FunctionFilter  = { $Func = $_; $FunctionName.ForEach({ $Func.Name -like $_ }) -contains $true }.GetNewClosure()


### PR DESCRIPTION
Fixing `Add-Parameter` function using an `if` statement expression instead of the ternary operator, because it was causing parsing error in Windows PowerShell / PS5.1.